### PR TITLE
Bind +use to Space by default

### DIFF
--- a/src/engine/defconfig.inc
+++ b/src/engine/defconfig.inc
@@ -13,6 +13,7 @@
 "bind A \"+strafeleft\"\n"
 "bind S \"+back\"\n"
 "bind E \"+use\"\n"
+"bind Space \"+use\"\n"
 "bind W \"+forward\"\n"
 "bind D \"+straferight\"\n"
 "bind Ctrl \"+fire\"\n"


### PR DESCRIPTION
Space isn't used for anything now that jumping has been removed and +use is meant to be on Space anyway; this is DOOM after all.