### PR TITLE
Menu adjustments

### DIFF
--- a/src/engine/gl_draw.c
+++ b/src/engine/gl_draw.c
@@ -353,6 +353,9 @@ int Center_Text(const char* string) {
         case 0x20:
             width += 6;
             break;
+        case '\n':
+            width = 0;
+            break;
         case '-':
             width += symboldata[SM_MISCFONT].w;
             break;
@@ -421,6 +424,7 @@ int Draw_BigText(int x, int y, rcolor color, const char* string) {
     if(x <= -1) {
         x = Center_Text(string);
     }
+    const int ix = x;
 
     y += 14;
 
@@ -442,10 +446,8 @@ int Draw_BigText(int x, int y, rcolor color, const char* string) {
         vy1 = (float)y;
 
         c = string[i];
-        if(c == '\n' || c == '\t') {
-            continue;    // villsa: safety check
-        }
-        else if(c == 0x20) {
+        
+        if(c == 0x20) {
             x += 6;
             continue;
         }
@@ -476,6 +478,20 @@ int Draw_BigText(int x, int y, rcolor color, const char* string) {
             }
             if(c == ':') {
                 index = SM_MISCFONT + 5;
+            }
+            if (c == '\t')
+            {
+                while (x % 40)
+                {
+                    x++;
+                }
+                continue;
+            }
+            if (c == '\n')
+            {
+                y += 12;
+                x = ix;
+                continue;
             }
 
             // [kex] use 'printf' style formating for special symbols


### PR DESCRIPTION
Changelog:
- Rearranged main menu
- Rearranged options menu
- Renamed Display to HUD
- Moved Always Run option under "Gameplay"
- Moved Brightness and Framerate options under Video
- Renamed Framerate to Interpolation and renamed its options to Off/On
- Fixed option to set resolution to 5:4 aspect ratios
- Added option hints to Video menu
- to support this, I added support for hints with \n to Center_Text and Draw_BigText (support in Center_Text is not very robust and requires you to add extra spaces to the hint string for it to render nicely)