### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,36 @@
-Doom64EX-Plus
-========
+# Doom 64 EX+
 
-# Info
+Doom 64 EX+ is a continuation project of Samuel "Kaiser" Villarreal's Doom 64 EX aimed to recreate DOOM 64 as closely as possible with additional modding features.
 
-Doom64EX-Plus is a reverse-engineering/Continuation project of The Kaiser's Doom64x. aimed to recreate Doom64 as close as possible with additional modding features.
+## Differences from Kaiser's C++ version of EX on GitHub:
 
-
-# Differences from Kaiser's C++ version on Github.
-
-* Support for the Nightdive IWAD
-* Support for the Lost Levels
-* Support for loading PWADS
-* Better performance (especially when compared to the official Nightdive version, which is slow as hell)
-* Secret notifications
-* MAP slots up to MAP40
-* The MEDKIT You Really Need fix
+* Support for the IWAD from Nightdive Studios' official remaster
+* Support for the Lost Levels campaign
+* Support for loading PWADs
+* Better performance (especially when compared to Nightdive Studios' official version which is slow as hell)
+* Messages for discovering secret areas
+* Support of MAP slots up to MAP40
+* The "medkit you REALLY need!" message fix
 * Many bugfixes
-* Kex - This is pretty much removed.  The only remnants are some comments with [kex] and the rendering stuff that is used in later versions.  I wanted to keep Doom64EX-Plus very close in format to other source ports, for familiarity purposes and ease-of-porting code from Erick's Doom64-RE project.
+* KEX - This is pretty much removed.  The only remnants are some comments with [kex] and the rendering stuff that is used in later versions. I wanted to keep Doom 64 EX+ very close in format to other source ports for familiarity purposes and for ease of porting code from Erick's DOOM64-RE project.
 
-There are a few bugs still present, which I am slowly fixing.  This GitHub repo is the same as: https://sourceforge.net/projects/doom64ex-plus/
+There are a few bugs still present, which I am slowly fixing.
 
-But if any contributors wish to help, then GitHub is a better place for it.
+This GitHub repo is the same as: https://sourceforge.net/projects/doom64ex-plus/ but if any contributors wish to help, then GitHub is a better place for it.
 
-# MOD Support
+## Mod Support
 
-For modders, wanting to make their mods for EX+ there are a few things that deviate from ancient EX.
+For modders wanting to make their mods work with EX+, there are a few things that deviate from ancient EX:
 
-1. DM_START and DM_END like the remaster, instead of DS_START and DS_END
-2. Graphics tags aren't implemented (like the remaster).  Instead:
-	a. The FIRST tag for graphics MUST BE 'SYMBOLS' (without the quotes)
-	b. The END tag for graphics MUST BE 'MOUNTC' (without the quotes)
-They can be either a tag or a graphic.  This is due to me not flat-out reading all PNG's in a WAD
-but instead, to support the official IWAD, I read the content like this to catch all the graphics that
-EX+ needs, from the IWAD.
+1. DM_START and DM_END tags are used (like the remaster) instead of DS_START and DS_END.
+2. G_START and G_END graphics tags aren't implemented (like the remaster).
+
+Instead:
+
+* The **first** tag for graphics **MUST BE** called SYMBOLS.
+* The **last** tag for graphics **MUST BE** called MOUNTC.
+
+They can either be a tag or a graphic.  This is due to me not flat-out reading all PNGs in a WAD but instead, to support the official IWAD, I read the content like this to catch all the graphics that EX+ needs from the IWAD.
 
 No other changes are needed.
 
@@ -46,22 +44,29 @@ No other changes are needed.
 
 ## Compiling
 
-### Linux, MSYS, cross compilation and MSVC 2022.
-
 Clone this repo
 
     $ git clone https://github.com/atsb/Doom64EX-Plus
-    
-For Linux, use the build.sh script.
-For cross compilation for Windows, use the build_win_cross.sh
-
-For Windows Only, use the provided Visual Studio Project/Solution file for 32bit or 64bit builds.
-
-## Usage
 
 ### Linux
 
-Doom64EX-Plus needs the Doom 64 data to be present in any of the following directories:
+Use the `build.sh` script for a native build and the `build_win_cross.sh` script for cross compilation for Windows.
+
+### Windows
+
+Use the Visual Studio solution and project files provided in the `Windows` directory of the repository for both 32-bit or 64-bit builds.
+
+## Usage
+
+Doom 64 EX+ needs the DOOM 64 asset data files to be present for you to be able to play the game. The data files are:
+
+* `DOOM64.wad`
+* `doom64ex-plus.wad`
+* `doomsnd.sf2`
+
+### Linux
+
+You can place the asset data described above to any of the following directories:
 
 * The directory in which `doom64ex-plus` resides
 * `$XDG_DATA_HOME/doom64ex-plus` (eg. `~/.local/share/doom64ex-plus`)
@@ -70,15 +75,14 @@ Doom64EX-Plus needs the Doom 64 data to be present in any of the following direc
 * `/usr/share/games/doom64ex-plus`
 * `/usr/share/doom64ex-plus`
 
-The data files are:
+Then, you can start playing:
 
-* `doom64ex-plus.wad`
-* `doom64.wad`
-* `doomsnd.sf2`
+    $ doom64ex-plus
 
 **NOTE for Linux users:** As of Feb. 24, 2016, the save data is located in `$XDG_DATA_HOME/doom64ex-plus` (typically `~/.local/share/doom64ex-plus`) and not in `~/.doom64ex-plus`. The files can be safely moved to their new home.
 
-After this you can play.
+### Windows
 
-    $ doom64ex-plus
-    
+The asset data files need to be located in the same directory as `Doom64EX-Plus.exe`.
+
+Then, you can start playing by launching `Doom64EX-Plus.exe` (or optionally by using `Doom64EX-Plus Launcher.exe` instead).


### PR DESCRIPTION
- Fixed typos and capitalization errors
- Improved lists
- Improved naming consistency - this project is now referred to as Doom 64 EX+  (subject to approval), official remaster is referred to as DOOM 64 (all capital DOOM is preferred style by Bethesda)
- Added info for Windows