### PR TITLE
Unfuq fluidsynth

### DIFF
--- a/Windows/Doom64EXPlus.vcxproj
+++ b/Windows/Doom64EXPlus.vcxproj
@@ -129,6 +129,8 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_LEAN_AND_MEAN;WINDOWS;_WIN32;_USE_XINPUT;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)..\src\engine\3rdparty\Includes</AdditionalIncludeDirectories>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -168,7 +170,9 @@
     <ClCompile Include="..\src\engine\g_settings.c" />
     <ClCompile Include="..\src\engine\info.c" />
     <ClCompile Include="..\src\engine\in_stuff.c" />
-    <ClCompile Include="..\src\engine\i_audio.c" />
+    <ClCompile Include="..\src\engine\i_audio.c">
+      <WholeProgramOptimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</WholeProgramOptimization>
+    </ClCompile>
     <ClCompile Include="..\src\engine\i_main.c" />
     <ClCompile Include="..\src\engine\i_png.c" />
     <ClCompile Include="..\src\engine\i_system.c" />
@@ -316,5 +320,5 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-  </ImportGroup>	
+  </ImportGroup>
 </Project>

--- a/src/engine/i_audio.c
+++ b/src/engine/i_audio.c
@@ -27,7 +27,6 @@
 //
 //-----------------------------------------------------------------------------
 
-#include <time.h>
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -1087,7 +1086,7 @@ static void Seq_Shutdown(doomseq_t* seq) {
 
 static int SDLCALL Thread_PlayerHandler(void* param) {
 	doomseq_t* seq = (doomseq_t*)param;
-	intptr_t start = clock();
+	intptr_t start = SDL_GetTicks();
 	intptr_t delay = 0;
 	int status;
 	dword count = 0;
@@ -1117,11 +1116,11 @@ static int SDLCALL Thread_PlayerHandler(void* param) {
 		//
 		// play some songs
 		//
-		Seq_RunSong(seq, clock() - start);
+		Seq_RunSong(seq, SDL_GetTicks() - start);
 		count++;
 
 		// try to avoid incremental time de-syncs
-		delay = count - (clock() - start);
+		delay = count - (SDL_GetTicks() - start);
 
 		if (delay > 0) {
 			SDL_Delay(delay);
@@ -1152,7 +1151,7 @@ void I_InitSequencer(void) {
 	// off-sync when uncapped framerates are enabled but for some
 	// reason, calling SDL_GetTicks before initalizing the thread
 	// will reduce the chances of it happening
-	clock();
+	SDL_GetTicks();
 
 	doomseq.thread = SDL_CreateThread(Thread_PlayerHandler, "SynthPlayer", &doomseq);
 	if (doomseq.thread == NULL) {

--- a/src/engine/i_audio.c
+++ b/src/engine/i_audio.c
@@ -1099,13 +1099,6 @@ static int SDLCALL Thread_PlayerHandler(void* param) {
 		//
 		Seq_RunSong(seq, GetTicks() - start);
 		count++;
-
-		// try to avoid incremental time de-syncs
-		delay = count - (GetTicks() - start);
-
-		if (delay > 0) {
-			SDL_Delay(delay);
-		}
 	}
 
 	return 0;

--- a/src/engine/i_audio.c
+++ b/src/engine/i_audio.c
@@ -111,7 +111,6 @@ static dboolean seqready = false;
 //
 
 #define MIDI_CHANNELS   64
-#define MIDI_MESSAGE    0x07
 #define MIDI_END        0x2f
 #define MIDI_SET_TEMPO  0x51
 #define MIDI_SEQUENCER  0x7f
@@ -617,17 +616,6 @@ static void Event_Meta(doomseq_t* seq, channel_t* chan) {
 	meta = Chan_GetNextMidiByte(chan);
 
 	switch (meta) {
-		// mostly for debugging/logging
-	case MIDI_MESSAGE:
-		b = Chan_GetNextMidiByte(chan);
-		dmemset(string, 0, 256);
-
-		for (i = 0; i < b; i++) {
-			string[i] = Chan_GetNextMidiByte(chan);
-		}
-
-		string[b + 1] = '\n';
-		break;
 
 	case MIDI_END:
 		b = Chan_GetNextMidiByte(chan);
@@ -636,18 +624,11 @@ static void Event_Meta(doomseq_t* seq, channel_t* chan) {
 
 	case MIDI_SET_TEMPO:
 		b = Chan_GetNextMidiByte(chan);   // length
-		if (b != 3) {
-			return;
-		}
 
 		chan->song->tempo =
 			(Chan_GetNextMidiByte(chan) << 16) |
 			(Chan_GetNextMidiByte(chan) << 8) |
 			(Chan_GetNextMidiByte(chan) & 0xff); // 1111
-
-		if (chan->song->tempo == 0) {
-			return;
-		}
 
 		chan->song->timediv = Song_GetTimeDivision(chan->song);
 		chan->starttime = chan->curtime;

--- a/src/engine/i_audio.c
+++ b/src/engine/i_audio.c
@@ -976,13 +976,6 @@ static dboolean Seq_RegisterSongs(doomseq_t* seq) {
 
 	seq->nsongs = (end - start) + 1;
 
-	//
-	// no midi songs found in iwad?
-	//
-	if (seq->nsongs <= 0) {
-		return false;
-	}
-
 	seq->songs = (song_t*)Z_Calloc(seq->nsongs * sizeof(song_t), PU_STATIC, 0);
 
 	fail = 0;
@@ -1072,13 +1065,6 @@ static int SDLCALL Thread_PlayerHandler(void* param) {
 
 		if (signal) {
 			status = signal(seq);
-
-			if (status == 0) {
-				// villsa 12292013 - add a delay here so we don't
-				// thrash the loop while idling
-				SDL_Delay(1);
-				continue;
-			}
 
 			if (status == -1) {
 				return 1;

--- a/src/engine/s_sound.c
+++ b/src/engine/s_sound.c
@@ -83,12 +83,6 @@ CVAR_CMD(s_musvol, 80) {
 	}
 	S_SetMusicVolume(cvar->value);
 }
-CVAR_CMD(s_gain, 1) {
-	if (cvar->value < 0.0f) {
-		return;
-	}
-	S_SetGainOutput(cvar->value);
-}
 
 //
 // Internals.
@@ -121,7 +115,6 @@ void S_Init(void) {
 
 	S_SetMusicVolume(s_musvol.value);
 	S_SetSoundVolume(s_sfxvol.value);
-	S_SetGainOutput(s_gain.value);
 }
 
 //
@@ -138,14 +131,6 @@ void S_SetSoundVolume(float volume) {
 
 void S_SetMusicVolume(float volume) {
 	I_SetMusicVolume(volume);
-}
-
-//
-// S_SetGainOutput
-//
-
-void S_SetGainOutput(float db) {
-	I_SetGain(db);
 }
 
 //
@@ -405,7 +390,6 @@ CVAR_EXTERNAL(s_driver);
 void S_RegisterCvars(void) {
 	CON_CvarRegister(&s_sfxvol);
 	CON_CvarRegister(&s_musvol);
-	CON_CvarRegister(&s_gain);
 	CON_CvarRegister(&s_soundfont);
 	CON_CvarRegister(&s_driver);
 }


### PR DESCRIPTION
A lot of improvements, streamlining and simplification.

1. ALSA default on Linux
2. Tempo isn't so strict (removed some things that would prevent it if tempo was 0 or bytes were not 3)
3. Removed IWAD checking of tracks since the remaster has FMOD tracks, we read them from the PWAD
4. Implemented pausing again and tried to fix the pausing issue.  Seems to happen on the PWAD midi tracks but not the tracks converted by Immorpher with the tool.  I will be converting all PWAD tracks to this improved format
5. Removed the Delay that was causing tracks with many notes to desync
6. Removed MUTEX and SEMAPHORE as it was thrashing the CPU on lower-end systems by constantly waiting and locking the threads.  Removing these just lets the damn midi play whenever it wants.  Why be so strict?