### PR TITLE
Fixed weapon bobbing while firing and fixed pistol fire rate

### DIFF
--- a/src/engine/p_pspr.c
+++ b/src/engine/p_pspr.c
@@ -249,8 +249,7 @@ dboolean P_CheckAmmo(player_t* player) {
 //
 // P_FireWeapon.
 //
-void P_FireWeapon(void* data) {
-	player_t* player = (player_t*)data;
+void P_FireWeapon(player_t* player) {
 	statenum_t    newstate;
 
 	if (!P_CheckAmmo(player)) {
@@ -258,7 +257,12 @@ void P_FireWeapon(void* data) {
 	}
 
 	P_SetMobjState(player->mo, S_PLAY_ATK1);
+	player->psprites[ps_weapon].sx = FRACUNIT;
+	player->psprites[ps_weapon].sy = WEAPONTOP;
 	newstate = weaponinfo[player->readyweapon].atkstate;
+	if (player->refire && player->readyweapon == wp_pistol) {
+		newstate++;
+	}
 	P_SetPsprite(player, ps_weapon, newstate);
 	P_NoiseAlert(player->mo, player->mo);
 }


### PR DESCRIPTION
Fixes #54 

Essentially reverts https://github.com/atsb/Doom64EX-Plus/commit/acb1fa2aca7e00ac34052c6391c5d568e1c8e87b#diff-addc062fdb874311527f9f8c54fb0b537ffee2524ff63677d0ad704a5010b175

The pistol refire needs to be like this. The same behaviour is in N64 and the official remaster and removing it nerfs the pistol's firing rate. I admit that this hack is an ugly way of achieving this but I didn't manage to find how it's done in Erick's RE codebase.

I also removed the cast in this function because it felt redundant. Apologies if it's actually some kind of galactic brain optimization.