### PR TITLE
Making it work with 64bit for D64

### DIFF
--- a/src/engine/i_w3swrapper.h
+++ b/src/engine/i_w3swrapper.h
@@ -45,9 +45,9 @@ typedef bool dboolean;
 
 #ifdef _WIN32
 #include <Windows.h>
-typedef BYTE			byte;
-typedef WORD			word;
-typedef DWORD			dword;
+typedef UINT8			byte;
+typedef UINT16			word;
+typedef UINT64			dword;
 #else
 typedef uint8_t         byte;
 typedef uint16_t		word;

--- a/src/engine/i_w3swrapper.h
+++ b/src/engine/i_w3swrapper.h
@@ -45,14 +45,20 @@ typedef bool dboolean;
 
 #ifdef _WIN32
 #include <Windows.h>
-typedef UINT8			byte;
-typedef UINT16			word;
-typedef UINT64			dword;
+#ifdef OLD_TYPE
+typedef uint8_t  byte;
+typedef uint16_t word;
+typedef uint64_t dword;
 #else
-typedef uint8_t         byte;
-typedef uint16_t		word;
-typedef uint64_t		dword;
+typedef UINT8  byte;
+typedef UINT16 word;
+typedef UINT64 dword;
 #endif
+#else
+typedef uint8_t  byte;
+typedef uint16_t word;
+typedef uint64_t dword
+#endif 
 
 #ifdef _WIN32
 #define w3sopen(FileName, OpenFlag, ...) _open(FileName, OpenFlag, __VA_ARGS__)


### PR DESCRIPTION
I changed this because DWORD etc..  cause issues with D64's shootable switches, shootable secrets and other things.  It seems to be incredibly sensitive to the width of the type used, so I used these, which are still standardised Windows'isms also.