### PR TITLE
Fixing lights that won't stop glowing

### DIFF
--- a/src/engine/p_lights.c
+++ b/src/engine/p_lights.c
@@ -261,6 +261,7 @@ void T_Glow(glow_t* g) {
 
 		if (g->sector->special != g->special)
 		{
+			g->sector->lightlevel = 0;
 			P_RemoveThinker(&g->thinker);
 			return;
 		}


### PR DESCRIPTION
This is most noticeable on MAP28 (The Absolution) with the artifact switches