### PR TITLE
New specials

### DIFF
--- a/src/engine/p_local.h
+++ b/src/engine/p_local.h
@@ -155,7 +155,7 @@ void        P_SpawnPuff(fixed_t x, fixed_t y, fixed_t z);
 void        P_SpawnBlood(fixed_t x, fixed_t y, fixed_t z, int damage);
 void        P_SpawnPlayerMissile(mobj_t* source, mobjtype_t type);
 void        P_FadeMobj(mobj_t* mobj, int amount, int alpha, int flags);
-int         EV_SpawnMobjTemplate(line_t* line);
+int         EV_SpawnMobjTemplate(line_t* line, boolean silent);
 int         EV_FadeOutMobj(line_t* line);
 void        P_SpawnDartMissile(int tid, int type, mobj_t* target);
 mobj_t* P_SpawnMissile(mobj_t* source, mobj_t* dest, mobjtype_t type,

--- a/src/engine/p_mobj.c
+++ b/src/engine/p_mobj.c
@@ -1367,7 +1367,7 @@ void P_SpawnDartMissile(int tid, int type, mobj_t* target) {
 			continue;
 		}
 
-		if (type == MT_PROJ_TRACER) {
+		if (type == MT_PROJ_TRACER || type == MT_PROJ_UNDEAD) {
 			th = P_SpawnMissile(mo, target, type,
 				FixedMul(mo->radius, dcos(mo->angle)),
 				FixedMul(mo->radius, dsin(mo->angle)),

--- a/src/engine/p_mobj.c
+++ b/src/engine/p_mobj.c
@@ -875,7 +875,7 @@ void P_CreateFadeOutThinker(mobj_t* mobj, line_t* line) {
 // EV_SpawnMobjTemplate
 //
 
-int EV_SpawnMobjTemplate(line_t* line) {
+int EV_SpawnMobjTemplate(line_t* line, boolean silent) {
 	mobj_t* mobj;
 	int i;
 	boolean ok = false;
@@ -902,7 +902,7 @@ int EV_SpawnMobjTemplate(line_t* line) {
 
 		mobj->reactiontime = 18;
 
-		if (m_nospawnsound.value != 1)
+		if (!silent && m_nospawnsound.value != 1)
 		{
 			S_StartSound(mobj, sfx_spawn);
 		}

--- a/src/engine/p_mobj.c
+++ b/src/engine/p_mobj.c
@@ -1367,7 +1367,7 @@ void P_SpawnDartMissile(int tid, int type, mobj_t* target) {
 			continue;
 		}
 
-		if (type == MT_PROJ_TRACER || type == MT_PROJ_UNDEAD) {
+		if (type == MT_PROJ_TRACER || type == MT_PROJ_RECT || type == MT_PROJ_UNDEAD) {
 			th = P_SpawnMissile(mo, target, type,
 				FixedMul(mo->radius, dcos(mo->angle)),
 				FixedMul(mo->radius, dsin(mo->angle)),

--- a/src/engine/p_setup.c
+++ b/src/engine/p_setup.c
@@ -1471,6 +1471,10 @@ static void P_InitSkyDef(void) {
 	CON_DPrintf("%i sky definitions\n", numskydef);
 }
 
+int P_GetNumSkies(void) {
+	return numskydef;
+}
+
 //
 // P_Init
 //

--- a/src/engine/p_setup.h
+++ b/src/engine/p_setup.h
@@ -66,4 +66,7 @@ typedef struct {
 	int         fognear;
 } skydef_t;
 
+void P_SetupSky(void);
+int P_GetNumSkies(void);
+
 #endif

--- a/src/engine/p_spec.c
+++ b/src/engine/p_spec.c
@@ -1606,6 +1606,11 @@ int P_DoSpecialLine(mobj_t* thing, line_t* line, int side) {
 		ok = 1;
 		break;
 
+	case 216:
+		//Change music
+		ok = P_ChangeMusic(line->tag);
+		break;
+
 	default:
 		CON_Warnf("P_DoSpecialLine: Unknown Special: %i\n", line->special);
 		return 0;
@@ -2134,5 +2139,21 @@ boolean P_StartSound(int index)
 		if (index + dm_start >= dm_end - 1) return false;
 	}
 	S_StartSound(players[consoleplayer].mo, index);
+	return true;
+}
+
+boolean P_ChangeMusic(int index)
+{
+	if (index <= 0) return false;
+	index += mus_amb01 - 1;
+	if (index > mus_title)
+	{
+		index += NUMSFX - mus_title - 1;
+		int dm_start = W_GetNumForName("DM_START");
+		int dm_end = W_GetNumForName("DM_END");
+		if (index + dm_start >= dm_end - 1) return false;
+	}
+	S_StopMusic();
+	S_StartMusic(index);
 	return true;
 }

--- a/src/engine/p_spec.c
+++ b/src/engine/p_spec.c
@@ -53,6 +53,7 @@
 #include "con_console.h"
 #include "r_sky.h"
 #include "sc_main.h"
+#include "p_setup.h"
 
 short globalint = 0;
 static byte tryopentype[3];
@@ -1611,6 +1612,11 @@ int P_DoSpecialLine(mobj_t* thing, line_t* line, int side) {
 		ok = P_ChangeMusic(line->tag);
 		break;
 
+	case 217:
+		//Change sky
+		ok = P_ChangeSky(line->tag);
+		break;
+
 	default:
 		CON_Warnf("P_DoSpecialLine: Unknown Special: %i\n", line->special);
 		return 0;
@@ -2155,5 +2161,17 @@ boolean P_ChangeMusic(int index)
 	}
 	S_StopMusic();
 	S_StartMusic(index);
+	return true;
+}
+
+boolean P_ChangeSky(int index)
+{
+	if (index <= 0) return false;
+	index -= 1;
+	if (index >= P_GetNumSkies()) return false;
+	int temp = skyflatnum;
+	skyflatnum = index;
+	P_SetupSky();
+	skyflatnum = temp;
 	return true;
 }

--- a/src/engine/p_spec.c
+++ b/src/engine/p_spec.c
@@ -1446,7 +1446,7 @@ int P_DoSpecialLine(mobj_t* thing, line_t* line, int side) {
 
 	case 224:
 		// Spawn Thing
-		ok = EV_SpawnMobjTemplate(line);
+		ok = EV_SpawnMobjTemplate(line, false);
 		break;
 
 	case 225:
@@ -1588,6 +1588,11 @@ int P_DoSpecialLine(mobj_t* thing, line_t* line, int side) {
 		// D64 Map33 Logo
 		skyfadeback = true;
 		ok = 1;
+		break;
+
+	case 211:
+		// Silent Spawn Thing
+		ok = EV_SpawnMobjTemplate(line, true);
 		break;
 
 	default:

--- a/src/engine/p_spec.c
+++ b/src/engine/p_spec.c
@@ -1600,6 +1600,11 @@ int P_DoSpecialLine(mobj_t* thing, line_t* line, int side) {
 		ok = P_StartSound(line->tag);
 		break;
 
+	case 215:
+		//Stop music
+		S_StopMusic();
+		ok = 1;
+		break;
 
 	default:
 		CON_Warnf("P_DoSpecialLine: Unknown Special: %i\n", line->special);

--- a/src/engine/p_spec.c
+++ b/src/engine/p_spec.c
@@ -1595,6 +1595,12 @@ int P_DoSpecialLine(mobj_t* thing, line_t* line, int side) {
 		ok = EV_SpawnMobjTemplate(line, true);
 		break;
 
+	case 213:
+		//Play sound
+		ok = P_StartSound(line->tag);
+		break;
+
+
 	default:
 		CON_Warnf("P_DoSpecialLine: Unknown Special: %i\n", line->special);
 		return 0;
@@ -2105,4 +2111,23 @@ void P_SpawnSpecials(void) {
 	for (i = 0; i < MAXBUTTONS; i++) {
 		dmemset(&buttonlist[i], 0, sizeof(button_t));
 	}
+}
+
+boolean P_StartSound(int index)
+{
+	if (index <= 0) return false;
+	if (index >= mus_amb01)
+	{
+		//skip music ordinals
+		index += mus_title - mus_amb01 + 1;
+	}
+	if (index >= NUMSFX)
+	{
+		//play custom sounds defined in pwads
+		int dm_start = W_GetNumForName("DM_START");
+		int dm_end = W_GetNumForName("DM_END");
+		if (index + dm_start >= dm_end - 1) return false;
+	}
+	S_StartSound(players[consoleplayer].mo, index);
+	return true;
 }

--- a/src/engine/p_spec.c
+++ b/src/engine/p_spec.c
@@ -1617,6 +1617,11 @@ int P_DoSpecialLine(mobj_t* thing, line_t* line, int side) {
 		ok = P_ChangeSky(line->tag);
 		break;
 
+	case 255:
+		//Spawn any projectile
+		ok = P_SpawnGenericMissile(line->tag, globalint, thing);
+		break;
+
 	default:
 		CON_Warnf("P_DoSpecialLine: Unknown Special: %i\n", line->special);
 		return 0;
@@ -2173,5 +2178,13 @@ boolean P_ChangeSky(int index)
 	skyflatnum = index;
 	P_SetupSky();
 	skyflatnum = temp;
+	return true;
+}
+
+boolean P_SpawnGenericMissile(int tid, int type, mobj_t* target) {
+	if (type <= 0) return false;
+	type -= 1;
+	if (type > NUMMOBJTYPES) return false;
+	P_SpawnDartMissile(tid, type, target);
 	return true;
 }

--- a/src/engine/p_spec.h
+++ b/src/engine/p_spec.h
@@ -177,6 +177,7 @@ void        P_FadeInBrightness(void);
 boolean		P_StartSound(int index);
 boolean		P_ChangeMusic(int index);
 boolean		P_ChangeSky(int index);
+boolean		P_SpawnGenericMissile(int tid, int type, mobj_t* target);
 
 typedef enum
 {

--- a/src/engine/p_spec.h
+++ b/src/engine/p_spec.h
@@ -174,6 +174,7 @@ void        T_Combine(combine_t* combine);
 boolean    P_ChangeLightByTag(int tag1, int tag2);
 int         P_DoSectorLightChange(line_t* line, short tag);
 void        P_FadeInBrightness(void);
+boolean		P_StartSound(int index);
 
 typedef enum
 {

--- a/src/engine/p_spec.h
+++ b/src/engine/p_spec.h
@@ -176,6 +176,7 @@ int         P_DoSectorLightChange(line_t* line, short tag);
 void        P_FadeInBrightness(void);
 boolean		P_StartSound(int index);
 boolean		P_ChangeMusic(int index);
+boolean		P_ChangeSky(int index);
 
 typedef enum
 {

--- a/src/engine/p_spec.h
+++ b/src/engine/p_spec.h
@@ -175,6 +175,7 @@ boolean    P_ChangeLightByTag(int tag1, int tag2);
 int         P_DoSectorLightChange(line_t* line, short tag);
 void        P_FadeInBrightness(void);
 boolean		P_StartSound(int index);
+boolean		P_ChangeMusic(int index);
 
 typedef enum
 {


### PR DESCRIPTION
Adds new line specials for mappers.

- 211: Spawns a thing silently. Arg=tid
- 213: Plays a sound. Arg=sound id
  - The sound id starts at 1 and is the ordinal of sfxenum_t at sounds.h, but skips entries from mus_amb01 to mus_title.
- 215: Stops music.
- 216: Changes music. Arg=music id
  - The music id starts at 1 and is the ordinal of sfxenum_t at sounds.h, starting at mus_amb01.
- 217: Changes the sky. Arg=sky id
  - The sky id starts at 1 and corresponds to the sky definition in skydefs.
- 255: Spawns any thing as a projectile. Arg=tid, globalint=thing type
  - The thing type starts at 1 and is the ordinal of mobjtype_t at info.h. Should only be used with projectiles.

Attached is a test wad. Each square triggers a different special. The central red square combos all together in a macro.

[NewTest.zip](https://github.com/atsb/Doom64EX-Plus/files/10473404/NewTest.zip)
