### PR TITLE
Fix console font scaling on HiDpi displays

### DIFF
--- a/src/engine/con_console.c
+++ b/src/engine/con_console.c
@@ -78,7 +78,7 @@ static int          console_nextcmd;
 
 char        console_inputbuffer[MAX_CONSOLE_INPUT_LEN];
 int         console_inputlength;
-boolean    console_initialized = false;
+boolean     console_initialized = false;
 
 //
 // CON_Init
@@ -113,6 +113,7 @@ void CON_Init(void) {
 	console_cmdhead = 0;
 	console_nextcmd = 0;
 	console_initialized = true;
+
 }
 
 //
@@ -462,7 +463,10 @@ boolean CON_Responder(event_t* ev) {
 // CON_Draw
 //
 
-#define CONFONT_SCALE   ((float)(video_width * SCREENHEIGHT) / (float)(video_width * video_height))
+extern float display_scale; // set in i_video.c
+
+#define CONFONT_SCALE   ((display_scale * SCREENHEIGHT) / video_height)
+
 #define CONFONT_YPAD    (16 * CONFONT_SCALE)
 
 void CON_Draw(void) {

--- a/src/engine/i_video.c
+++ b/src/engine/i_video.c
@@ -59,6 +59,7 @@ CVAR(v_height, 480);
 CVAR(v_windowed, 1);
 CVAR(v_windowborderless, 0);
 
+float display_scale = 1.0f;
 SDL_Surface* screen;
 int video_width;
 int video_height;
@@ -78,6 +79,7 @@ void I_InitScreen(void) {
 	int     p;
 	unsigned int  flags = 0;
 	char    title[256];
+	SDL_DisplayID displayid;
 
 	InWindow = (int)v_windowed.value;
 	InWindowBorderless = (int)v_windowborderless.value;
@@ -154,6 +156,19 @@ void I_InitScreen(void) {
 		I_Error("I_InitScreen: Failed to create OpenGL context");
 		return;
 	}
+	
+	displayid = SDL_GetDisplayForWindow(window);
+	if(displayid) {
+		float f = SDL_GetDisplayContentScale(displayid);
+		if(f != 0) {
+			display_scale = f;	   
+		} else {
+			I_Printf("SDL_GetDisplayContentScale failed (%s)", SDL_GetError());
+		}
+	} else {
+		I_Printf("SDL_GetDisplays failed (%s)", SDL_GetError());
+	}
+
 	SDL_HideCursor();
 }
 

--- a/src/engine/i_video.c
+++ b/src/engine/i_video.c
@@ -166,7 +166,7 @@ void I_InitScreen(void) {
 			I_Printf("SDL_GetDisplayContentScale failed (%s)", SDL_GetError());
 		}
 	} else {
-		I_Printf("SDL_GetDisplays failed (%s)", SDL_GetError());
+		I_Printf("SDL_GetDisplayForWindow failed (%s)", SDL_GetError());
 	}
 
 	SDL_HideCursor();


### PR DESCRIPTION
This uses the new `SDL_GetDisplayContentScale` API to retrieve the scale factor of the window
(for example 250% scaling set in the OS results in display scale = 2.5f) and apply it to console scaling.
This fixes console font being very hard to read on Hi-Dpi displays.