### PR TITLE
fix GCC warnings with -Wall. Some are logic errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC=gcc
 
 libs := sdl3 libpng gl glu fluidsynth
 
-CFLAGS += $(foreach lib,$(libs),$(shell pkg-config --cflags $(lib)))
+CFLAGS += $(foreach lib,$(libs),$(shell pkg-config --cflags $(lib))) -Wall -Wno-pointer-sign -Wno-unknown-pragmas -Wno-missing-braces
 LDFLAGS := -lm $(foreach lib,$(libs),$(shell pkg-config --libs $(lib)))
 
 OBJDIR=src/engine

--- a/src/engine/con_console.c
+++ b/src/engine/con_console.c
@@ -251,7 +251,7 @@ void CON_DPrintf(const char* s, ...) {
 
 static boolean shiftdown = false;
 
-void CON_ParseKey(char c) {
+void CON_ParseKey(int c) {
 	if (c < ' ') {
 		return;
 	}

--- a/src/engine/con_cvar.c
+++ b/src/engine/con_cvar.c
@@ -109,7 +109,6 @@ char* CON_CvarString(char* name) {
 
 void CON_CvarSet(char* var_name, char* value) {
 	cvar_t* var;
-	boolean changed;
 
 	var = CON_CvarGet(var_name);
 	if (!var) {
@@ -118,7 +117,7 @@ void CON_CvarSet(char* var_name, char* value) {
 		return;
 	}
 
-	changed = dstrcmp(var->string, value);
+	dstrcmp(var->string, value);
 
 	Z_Free(var->string);    // free the old value string
 

--- a/src/engine/f_finale.c
+++ b/src/engine/f_finale.c
@@ -154,11 +154,11 @@ int F_Ticker(void) {
 
 	if (!castdeath) {
 		if (pc->key[PCKEY_LEFT]) {
-			castrotation = castrotation + 1 & 7;
+			castrotation = (castrotation + 1) & 7;
 			pc->key[PCKEY_LEFT] = 0;
 		}
 		else if (pc->key[PCKEY_RIGHT]) {
-			castrotation = castrotation - 1 & 7;
+			castrotation = (castrotation - 1) & 7;
 			pc->key[PCKEY_RIGHT] = 0;
 		}
 		else if (players[consoleplayer].cmd.buttons) {
@@ -166,9 +166,9 @@ int F_Ticker(void) {
 		}
 	}
 
-	finalePal.r = MIN(finalePal.r += 2, 250);
-	finalePal.g = MIN(finalePal.g += 2, 250);
-	finalePal.b = MIN(finalePal.b += 2, 250);
+	finalePal.r = MIN(finalePal.r + 2, 250);
+	finalePal.g = MIN(finalePal.g + 2, 250);
+	finalePal.b = MIN(finalePal.b + 2, 250);
 
 	if (!castdeath && castdying) {
 		S_StartSound(NULL, sfx_shotgun);

--- a/src/engine/g_actions.c
+++ b/src/engine/g_actions.c
@@ -420,6 +420,7 @@ boolean G_ActionResponder(event_t* ev) {
 		I_XInputReadActions(ev);
 		break;
 #endif
+	default:
 	}
 
 	return false;
@@ -638,6 +639,7 @@ boolean G_BindActionByEvent(event_t* ev, char* action) {
 			plist = &MouseActions[button];
 		}
 		break;
+	default:
 	}
 	if (plist) {
 		G_BindAction(plist, action);

--- a/src/engine/i_sdlinput.c
+++ b/src/engine/i_sdlinput.c
@@ -431,6 +431,19 @@ int I_ShutdownWait(void) {
 }
 
 //
+// I_InitInputs
+//
+
+void I_InitInputs(void) {
+	SDL_PumpEvents();
+	I_MouseAccelChange();
+
+#if defined(_WIN32) && defined(USE_XINPUT)
+	I_XInputInit();
+#endif
+}
+
+//
 // I_StartTic
 //
 
@@ -457,19 +470,6 @@ void I_FinishUpdate(void) {
 	SDL_GL_SwapWindow(window);
 
 	BusyDisk = false;
-}
-
-//
-// I_InitInputs
-//
-
-void I_InitInputs(void) {
-	SDL_PumpEvents();
-	I_MouseAccelChange();
-
-#if defined(_WIN32) && defined(USE_XINPUT)
-	I_XInputInit();
-#endif
 }
 
 //

--- a/src/engine/i_sdlinput.h
+++ b/src/engine/i_sdlinput.h
@@ -45,10 +45,6 @@ void I_MouseAccelChange(void);
 
 void ISDL_RegisterKeyCvars(void);
 
-static void I_GetEvent(SDL_Event* Event);
-static void I_ReadMouse(void);
-static void I_InitInputs(void);
-
 void I_StartTic(void);
 void I_FinishUpdate(void);
 int I_ShutdownWait(void);

--- a/src/engine/m_menu.c
+++ b/src/engine/m_menu.c
@@ -942,12 +942,6 @@ void M_DrawNetwork(void) {
 		"10 Minutes"
 	};
 
-	static const char* networkscalestrings[3] = {
-		"x 1",
-		"x 2",
-		"x 3"
-	};
-
 #define DRAWNETWORKITEM(a, b, c) \
     if(currentMenu->menupageoffset <= a && \
         a - currentMenu->menupageoffset < currentMenu->numpageitems) \
@@ -2572,7 +2566,7 @@ void M_Features(int choice) {
 }
 
 void M_DrawFeaturesMenu(void) {
-	mapdef_t* map = P_GetMapInfo(levelwarp + 1);
+	P_GetMapInfo(levelwarp + 1);
 
 	/*Lock Monsters Mode*/
 	M_DrawSmbString(msgNames[(int)sv_lockmonsters.value], &featuresDef, features_lockmonsters);

--- a/src/engine/p_enemy.c
+++ b/src/engine/p_enemy.c
@@ -346,6 +346,7 @@ static mobj_t* P_MissileAttack(mobj_t* actor, int direction) {
 		type = MT_PROJ_BRUISER1;
 		aim = true;
 		break;
+	default:
 	}
 
 	deltax = FixedMul(offs * FRACUNIT, finecosine[angle]);
@@ -1806,10 +1807,8 @@ void A_Explode(mobj_t* thingy) {
 //
 
 void A_BarrelExplode(mobj_t* actor) {
-	mobj_t* exp;
-
 	S_StartSound(actor, sfx_explode);
-	exp = P_SpawnMobj(actor->x + FRACUNIT, actor->y + FRACUNIT, actor->z + (actor->height << 1), MT_EXPLOSION1);
+	P_SpawnMobj(actor->x + FRACUNIT, actor->y + FRACUNIT, actor->z + (actor->height << 1), MT_EXPLOSION1);
 	A_Explode(actor);
 
 	A_OnDeathTrigger(actor);

--- a/src/engine/p_inter.c
+++ b/src/engine/p_inter.c
@@ -307,6 +307,7 @@ static boolean P_GiveCard(player_t* player, mobj_t* item, card_t card) {
 		player->message = GOTREDSKULL;
 		player->messagepic = 30;
 		break;
+	default:
 	}
 
 	if (netgame) {
@@ -1011,7 +1012,6 @@ void P_DamageMobj(mobj_t* target, mobj_t* inflictor, mobj_t* source, int damage)
 	int         saved;
 	player_t* player;
 	fixed_t     thrust;
-	int         temp;
 
 	if (!(target->flags & MF_SHOOTABLE)) {
 		return;    // shouldn't happen...
@@ -1120,7 +1120,6 @@ void P_DamageMobj(mobj_t* target, mobj_t* inflictor, mobj_t* source, int damage)
 			player->damagecount = 100;    // teleport stomp does 10k points...
 		}
 
-		temp = damage < 100 ? damage : 100;
 	}
 
 	// do the damage

--- a/src/engine/p_macros.c
+++ b/src/engine/p_macros.c
@@ -60,12 +60,9 @@ void P_QueueSpecial(mobj_t* mobj) {
 //
 
 void P_RestartMacro(int id) {
-	int i = 0;
 	macrodata_t* m;
 
-	m = macro->data;
-
-	for (i = m->id; m != &macro->data[macro->count]; m++) {
+	for (m = macro->data ; m != &macro->data[macro->count]; m++) {
 		if (m->id == id) {
 			nextmacro = m;
 			return;

--- a/src/engine/p_mobj.c
+++ b/src/engine/p_mobj.c
@@ -857,7 +857,7 @@ void P_CreateFadeThinker(mobj_t* mobj, line_t* line) {
 //
 
 void P_CreateFadeOutThinker(mobj_t* mobj, line_t* line) {
-	int flags;
+	int flags = 0;
 
 	if (mobj->flags & MF_SHOOTABLE) {
 		flags |= MF_SHOOTABLE;

--- a/src/engine/p_plats.c
+++ b/src/engine/p_plats.c
@@ -102,6 +102,7 @@ void T_PlatRaise(plat_t* plat) {
 			case customUpDownFast:
 				P_RemoveActivePlat(plat);
 				break;
+			default:
 			}
 		}
 		break;

--- a/src/engine/p_pspr.c
+++ b/src/engine/p_pspr.c
@@ -317,7 +317,7 @@ void A_WeaponReady(player_t* player, pspdef_t* psp) {
 	}
 
 	// bob the weapon based on movement speed
-	angle = (128 * leveltime) & FINEANGLES - 1;
+	angle = ((128 * leveltime) & FINEANGLES) - 1;
 	psp->sx = FRACUNIT + FixedMul(player->bob, finecosine[angle]);
 	angle &= FINEANGLES / 2 - 1;
 	psp->sy = WEAPONTOP + FixedMul(player->bob, finesine[angle]);
@@ -599,7 +599,6 @@ void P_BulletSlope(mobj_t* mo) {
 void P_GunShot(mobj_t* mo, boolean accurate) {
 	angle_t     angle;
 	int         damage;
-	int         rnd1, rnd2;
 
 	damage = ((P_Random() & 3) * 4) + 4;
 	angle = mo->angle;

--- a/src/engine/p_telept.c
+++ b/src/engine/p_telept.c
@@ -159,9 +159,6 @@ int EV_Teleport(line_t* line, int side, mobj_t* thing) {
 int EV_SilentTeleport(line_t* line, mobj_t* thing) {
 	int         tag;
 	mobj_t* m;
-	fixed_t     oldx;
-	fixed_t     oldy;
-	fixed_t     oldz;
 
 	tag = line->tag;
 	for (m = mobjhead.next; m != &mobjhead; m = m->next) {
@@ -174,10 +171,6 @@ int EV_SilentTeleport(line_t* line, mobj_t* thing) {
 		if (m->tid != tag) {
 			continue;
 		}
-
-		oldx = thing->x;
-		oldy = thing->y;
-		oldz = thing->z;
 
 		if (thing->player) {
 			P_Telefrag(thing, m->x, m->y);

--- a/src/engine/st_stuff.c
+++ b/src/engine/st_stuff.c
@@ -820,6 +820,7 @@ void ST_Drawer(void) {
 			case am_cell:
 				Draw_Sprite2D(SPR_CELL, 0, 0, 524, 464, 0.5f, 0, WHITEALPHA(0xC0));
 				break;
+			default:
 			}
 
 			// display artifact sprites
@@ -1233,7 +1234,7 @@ static void ST_DrawChatText(void) {
 	}
 
 	if (st_chatOn) {
-		char tmp[MAXCHATSIZE];
+		char tmp[MAXCHATSIZE+2];
 
 		sprintf(tmp, "%s_", st_chatstring[consoleplayer]);
 		Draw_Text(STCHATX, STCHATY + 8, WHITE, 0.5f, false, tmp);


### PR DESCRIPTION
This fixes these warnings given by GCC with -Wall. Some of them seems to be logic errors (please review).
In particular the 2 ones with operator `&` having precedence over `+` and `-`. 


```
src/engine/st_stuff.c: In function ‘ST_DrawChatText’:
src/engine/st_stuff.c:1238:34: warning: ‘sprintf’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
 1238 |                 sprintf(tmp, "%s_", st_chatstring[consoleplayer]);
      |                                  ^
src/engine/st_stuff.c:1238:17: note: ‘sprintf’ output between 2 and 257 bytes into a destination of size 256
 1238 |                 sprintf(tmp, "%s_", st_chatstring[consoleplayer]);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

------------


src/engine/p_telept.c: In function ‘EV_SilentTeleport’:
src/engine/p_telept.c:164:21: warning: variable ‘oldz’ set but not used [-Wunused-but-set-variable]
  164 |         fixed_t     oldz;
      |                     ^~~~
src/engine/p_telept.c:163:21: warning: variable ‘oldy’ set but not used [-Wunused-but-set-variable]
  163 |         fixed_t     oldy;
      |                     ^~~~
src/engine/p_telept.c:162:21: warning: variable ‘oldx’ set but not used [-Wunused-but-set-variable]
  162 |         fixed_t     oldx;
      |                     ^~~~

--------------------

src/engine/p_pspr.c: In function ‘P_GunShot’:
src/engine/p_pspr.c:602:27: warning: unused variable ‘rnd2’ [-Wunused-variable]
  602 |         int         rnd1, rnd2;
      |                           ^~~~
src/engine/p_pspr.c:602:21: warning: unused variable ‘rnd1’ [-Wunused-variable]
  602 |         int         rnd1, rnd2;

-----------------------

src/engine/p_pspr.c: In function ‘A_WeaponReady’:
src/engine/p_pspr.c:320:35: warning: suggest parentheses around ‘-’ in operand of ‘&’ [-Wparentheses]
  320 |         angle = (128 * leveltime) & FINEANGLES - 1;


----------------------------
src/engine/p_plats.c: In function ‘T_PlatRaise’:
src/engine/p_plats.c:98:25: warning: enumeration value ‘perpetualRaise’ not handled in switch [-Wswitch]
   98 |                         switch (plat->type) {
      |                         ^~~~~~
src/engine/p_plats.c:98:25: warning: enumeration value ‘downWaitUpStay’ not handled in switch [-Wswitch]
src/engine/p_plats.c:98:25: warning: enumeration value ‘raiseAndChange’ not handled in switch [-Wswitch]
src/engine/p_plats.c:98:25: warning: enumeration value ‘raiseToNearestAndChange’ not handled in switch [-Wswitch]
src/engine/p_plats.c:98:25: warning: enumeration value ‘blazeDWUS’ not handled in switch [-Wswitch]
src/engine/p_plats.c:98:25: warning: enumeration value ‘customDownUp’ not handled in switch [-Wswitch]
src/engine/p_plats.c:98:25: warning: enumeration value ‘customDownUpFast’ not handled in switch [-Wswitch]

------------------------


src/engine/p_mobj.c: In function ‘P_CreateFadeOutThinker’:
src/engine/p_mobj.c:863:23: warning: ‘flags’ may be used uninitialized [-Wmaybe-uninitialized]
  863 |                 flags |= MF_SHOOTABLE;
      |                       ^~
src/engine/p_mobj.c:860:13: note: ‘flags’ was declared here
  860 |         int flags;

-----------------------


src/engine/p_inter.c: In function ‘P_DamageMobj’:
src/engine/p_inter.c:1014:21: warning: variable ‘temp’ set but not used [-Wunused-but-set-variable]
 1014 |         int         temp;

-----------------------

src/engine/p_inter.c: In function ‘P_GiveCard’:
src/engine/p_inter.c:285:9: warning: enumeration value ‘NUMCARDS’ not handled in switch [-Wswitch]
  285 |         switch (card) {

---------------------------


src/engine/p_enemy.c: In function ‘A_BarrelExplode’:
src/engine/p_enemy.c:1809:17: warning: variable ‘exp’ set but not used [-Wunused-but-set-variable]
 1809 |         mobj_t* exp;

-------------------------

src/engine/m_menu.c: In function ‘M_DrawNetwork’:
src/engine/m_menu.c:945:28: warning: unused variable ‘networkscalestrings’ [-Wunused-variable]
  945 |         static const char* networkscalestrings[3] = {
      |                            ^~~~~~~~~~~~~~~~~~~

--------------------------------

src/engine/m_menu.c: In function ‘M_DrawFeaturesMenu’:
src/engine/m_menu.c:2575:19: warning: unused variable ‘map’ [-Wunused-variable]
 2575 |         mapdef_t* map = P_GetMapInfo(levelwarp + 1);

----------------

src/engine/g_actions.c: In function ‘G_ActionResponder’:
src/engine/g_actions.c:393:9: warning: enumeration value ‘ev_gamepad’ not handled in switch [-Wswitch]
  393 |         switch (ev->type) {
      |         ^~~~~~
src/engine/g_actions.c: In function ‘G_BindActionByEvent’:
src/engine/g_actions.c:628:9: warning: enumeration value ‘ev_keyup’ not handled in switch [-Wswitch]
  628 |         switch (ev->type) {
      |         ^~~~~~
src/engine/g_actions.c:628:9: warning: enumeration value ‘ev_mouseup’ not handled in switch [-Wswitch]
src/engine/g_actions.c:628:9: warning: enumeration value ‘ev_gamepad’ not
handled in switch [-Wswitch]

-----------------------

src/engine/f_finale.c: In function ‘F_Ticker’:
src/engine/f_finale.c:157:53: warning: suggest parentheses around ‘+’ in operand of ‘&’ [-Wparentheses]
  157 |                         castrotation = castrotation + 1 & 7;
      |                                        ~~~~~~~~~~~~~^~~
src/engine/f_finale.c:161:53: warning: suggest parentheses around ‘-’ in operand of ‘&’ [-Wparentheses]
  161 |                         castrotation = castrotation - 1 & 7;
      |                                        ~~~~~~~~~~~~~^~~
src/engine/f_finale.c:169:21: warning: operation on ‘finalePal.r’ may be undefined [-Wsequence-point]
  169 |         finalePal.r = MIN(finalePal.r += 2, 250);
src/engine/f_finale.c:170:21: warning: operation on ‘finalePal.g’ may be undefined [-Wsequence-point]
  170 |         finalePal.g = MIN(finalePal.g += 2, 250);
src/engine/f_finale.c:171:21: warning: operation on ‘finalePal.b’ may be undefined [-Wsequence-point]
  171 |         finalePal.b = MIN(finalePal.b += 2, 250);



----------

src/engine/con_cvar.c: In function ‘CON_CvarSet’:
src/engine/con_cvar.c:112:17: warning: variable ‘changed’ set but not used [-Wunused-but-set-variable]
  112 |         boolean changed;

---------------

src/engine/con_console.c: In function ‘CON_ParseKey’:
src/engine/con_console.c:268:31: warning: array subscript has type ‘char’ [-Wchar-subscripts]
  268 |                 c = shiftxform[c];
```

--------------------------


There is also that one that I did not address, as I do not know if it is a bug where the function should return `rtn` (or not):

```
src/engine/p_lights.c: In function ‘P_DoSectorLightChange’:
src/engine/p_lights.c:609:13: warning: variable ‘rtn’ set but not used [-Wunused-but-set-variable]
  609 |         int rtn;
```