### PR TITLE
Improve data dir handling on Linux and OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,11 @@ GNU/Linux / BSD
 
 - GNU/Linux and BSD supports system installations using the compile-time macro *-DDOOM_UNIX_INSTALL*
 	this will force the software to look for all IWAD and supporting files inside ~/.local/share/doom64ex-plus
+- compile-time macro *-DDOOM_UNIX_SYSTEM_DATADIR=\"<path>\"* allows to specify the system folder where the software will look
+for all IWAD and supporting files. if not specified, it defaults to `/usr/local/share/doom64ex-plus`.
+Packagers should set `DOOM_UNIX_SYSTEM_DATADIR` to a proper folder for the distro and package files `doom64ex-plus.wad` and `doomsnd.sf2` into that folder.
 
-Without the macro, it will look inside the current directory that the binary is in.
+Finally, if a data file cannot be found in one of the two folders above, it will look inside the current directory that the binary is in.
 
 Packaging will not be done by myself, but any contributor is welcome to package the software for GNU/Linux or macOS.
 
@@ -150,10 +153,13 @@ Doom 64 EX+ needs the DOOM 64 asset data files to be present for you to be able 
 
 ## Linux, FreeBSD/OpenBSD and Raspberry pi3
 
-You can place the asset data described above to any of the following directories:
+You can place the asset data described above into any of the following directories,
+searched in that order:
 
-* The directory in which `doom64ex-plus` resides
-* `/usr/local/share/doom64ex-plus` or `/usr/share/games/doom64ex-plus`
+* `~/.local/share/doom64ex-plus` if compiled with the `DOOM_UNIX_INSTALL` macro
+* the folder specified by the `DOOM_UNIX_SYSTEM_DATADIR` compile macro, or `/usr/local/share/doom64ex-plus` if not specified
+
+If data files are not found in these directories, it will search in the current directory.
 
 ## macOS
 

--- a/src/engine/i_system.c
+++ b/src/engine/i_system.c
@@ -328,37 +328,22 @@ char* I_FindDataFile(char* file) {
 	}
 #endif
 
-	if ((dir = I_GetUserDir())) {
-		snprintf(path, 511, "%s%s", dir, file);
-           
-          Free(dir);
-
-		if (I_FileExists(path))
-			return path;
-	}
-
 #if defined(__linux__) || defined(__OpenBSD__)
-	{
-		int i;
-		const char* paths[] = {
-			//André: Removed all useless directories, Only The dir usr/local is fine to use.
-				//"/usr/local/share/games/doom64ex-plus/",
-				"/usr/local/share/doom64ex-plus/",
-				//"/usr/local/share/doom/",
-				//"/usr/share/games/doom64ex-plus/",
-				//"/usr/share/doom64ex-plus/",
-				//"/usr/share/doom/",
-				//"/opt/doom64ex-plus/",
-		};
 
-		for (i = 0; i < sizeof(paths) / sizeof(*paths); i++) {
-			snprintf(path, 511, "%s%s", paths[i], file);
-			if (I_FileExists(path))
-				return path;
-		}
-	}
+#ifndef DOOM_UNIX_SYSTEM_DATADIR
+#define DOOM_UNIX_SYSTEM_DATADIR "/usr/local/share/doom64ex-plus"
 #endif
+	// system directory
+	snprintf(path, 511, "%s/%s", DOOM_UNIX_SYSTEM_DATADIR, file);
+	if (I_FileExists(path))
+		return path;
 
+	// current directory
+	snprintf(path, 511, "%s", file);
+	if (I_FileExists(path))
+		return path;
+#endif
+	
 	Free(path);
 	
 	return NULL;


### PR DESCRIPTION
- added compile macro DOOM_UNIX_SYSTEM_DATADIR for specifying a system folder for data files
- fixed current directory not being searched for data files
- updated README