### PR TITLE
Fix segfault on crushing

### DIFF
--- a/src/engine/p_map.c
+++ b/src/engine/p_map.c
@@ -1692,13 +1692,13 @@ boolean PIT_ChangeSector(mobj_t* thing) {
             P_DamageMobj(thing, NULL, NULL, 10);
 
             // spray blood in a random direction
-            if (mo->type == MT_BRUISER2) {
+            if (thing->type == MT_BRUISER2) {
                 mo = P_SpawnMobj(thing->x, thing->y, thing->z + thing->height / 2, MT_BLOOD_GREEN);
             }
-            else if (mo->type == MT_IMP2) {
+            else if (thing->type == MT_IMP2) {
                 mo = P_SpawnMobj(thing->x, thing->y, thing->z + thing->height / 2, MT_BLOOD_PURPLE);
             }
-            else if (mo->type == MT_SKULL) {
+            else if (thing->type == MT_SKULL) {
                 mo = P_SpawnMobj(thing->x, thing->y, thing->z + thing->height / 2, MT_SMOKE_GRAY);
             }
             else {


### PR DESCRIPTION
`mo` is NULL at this point and will always result in segfault.
Thing is the actor that is crushed i.e. the player or a green blooded BRUISER2.

Easily reproducible by warping into map 32 (Hectic, the first secret level) and trying to grab the green armor.