### PR TITLE
Fix s_driver cvar

### DIFF
--- a/src/engine/i_audio.c
+++ b/src/engine/i_audio.c
@@ -70,21 +70,10 @@ CVAR_CMD(s_driver, sndio)
 {
     char* driver = cvar->string;
 
-    // this is absolutely horrible
-    if (!dstrcmp(cvar->defvalue, "default")) {
-        cvar->defvalue = DEFAULT_FLUID_DRIVER;
-    }
-
-    // same as above
-    if (!dstrcmp(driver, "default")) {
-        CON_CvarSet(cvar->name, DEFAULT_FLUID_DRIVER);
-        return;
-    }
-
     if (!dstrcmp(driver, "jack") ||
         !dstrcmp(driver, "alsa") ||
         !dstrcmp(driver, "oss") ||
-        !dstrcmp(driver, "alsa") ||
+        !dstrcmp(driver, "pulseaudio") ||
         !dstrcmp(driver, "coreaudio") ||
         !dstrcmp(driver, "dsound") ||
         !dstrcmp(driver, "portaudio") ||

--- a/src/engine/i_audio.h
+++ b/src/engine/i_audio.h
@@ -23,14 +23,14 @@
 #ifndef __I_AUDIO_H__
 #define __I_AUDIO_H__
 
-// 20120107 bkw: Linux users can change the default FluidSynth backend here:
-#ifndef _WIN32
-#define DEFAULT_FLUID_DRIVER "sndio"
-
-// 20120203 villsa: add default for windows
-#else
+#ifdef _WIN32
 #define DEFAULT_FLUID_DRIVER "dsound"
-
+#elif __linux__
+#define DEFAULT_FLUID_DRIVER "alsa"
+#elif __APPLE__
+#define DEFAULT_FLUID_DRIVER "coreaudio"
+#else
+#define DEFAULT_FLUID_DRIVER "sndio"
 #endif
 
 typedef struct {

--- a/src/engine/s_sound.c
+++ b/src/engine/s_sound.c
@@ -413,6 +413,7 @@ void S_RegisterCvars(void) {
     CON_CvarRegister(&s_musvol);
     CON_CvarRegister(&s_gain);
     CON_CvarRegister(&s_soundfont);
+    CON_CvarRegister(&s_driver);
 }
 
 


### PR DESCRIPTION
This merge request does 4 things:

* It properly registers s_driver. Without this the cvar can not be used and it will always just use the value set in the `CVAR_CMD` call.
* Fixes the list of possible values having alsa twice and missing pulseaudio (even tho the list below had it).
* Sets `DEFAULT_FLUID_DRIVER` to the same value as the default from the `CVAR_CMD`. Sadly C/C++ doesn't allow nested macros so we need this code to be doubled.
* I removed the "default" code as it was never used before and now somebody would have to manually change the value to "default" at which point it is easier to just remove the key from the config file. Comments also said it was horrible so I guess it was not wanted to begin with. Given how this is currently coded setting it to "default" would print out that it's not a valid driver and set it to the actual default anyway.

This makes the cvar now work properly. to change the cvar you can just type `seta s_driver pulseaudio` into the console, per `-setvars` command line argument, or change it in the config. No more recompiling just to change the driver. The only downside is that this doesn't restart fluidsynth so the game has to be restarted for it to take affect if it was set with the console.