### PR TITLE
fix compilation failure with GCC

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ GNU/Linux / BSD
 - GNU/Linux and BSD supports system installations using the compile-time macro *-DDOOM_UNIX_INSTALL*
 	this will force the software to look for all IWAD and supporting files inside `~/.local/share/doom64ex-plus`
 - compile-time macro *-DDOOM_UNIX_SYSTEM_DATADIR=\\"/some/system/path\\"* allows to specify the system folder where the software will look
-for all IWAD and supporting files. if not specified, it defaults to `/usr/local/share/doom64ex-plus`.
+for all IWAD and supporting files.
 Packagers should set *DOOM_UNIX_SYSTEM_DATADIR* to a proper folder for the distro and package files `doom64ex-plus.wad` and `doomsnd.sf2` into that folder.
 
 Finally, if a data file cannot be found in one of the two folders above, it will look inside the current directory.

--- a/src/engine/i_system.c
+++ b/src/engine/i_system.c
@@ -286,7 +286,7 @@ char* I_GetUserFile(char* file) {
  * @return Fully-qualified path or NULL if not found.
  */
 
-char* I_FindDataFile(const char* file) {
+char* I_FindDataFile(char* file) {
 	char* path = malloc(512);
 	const char* dir;
 
@@ -302,10 +302,12 @@ char* I_FindDataFile(const char* file) {
 	}
 
 #if !defined(_WIN32)
+#ifdef DOOM_UNIX_SYSTEM_DATADIR
 	snprintf(path, 511, "%s/%s", DOOM_UNIX_SYSTEM_DATADIR, file);
 	if (I_FileExists(path)) {
 		return path;
 	}
+#endif
 
 	snprintf(path, 511, "%s", file);
 	if (I_FileExists(path)) {


### PR DESCRIPTION
Fixes this GCC error:

```
[    9s] src/engine/i_system.c: At top level:
[    9s] src/engine/i_system.c:289:7: error: conflicting types for ‘I_FindDataFile’; have ‘char *(const char *)’
[    9s]   289 | char* I_FindDataFile(const char* file) {
[    9s]       |       ^~~~~~~~~~~~~~
[    9s] In file included from src/engine/dgl.h:35,
[    9s]                  from src/engine/doomdef.h:70,
[    9s]                  from src/engine/doomdata.h:31,
[    9s]                  from src/engine/doomstat.h:29,
[    9s]                  from src/engine/i_system.c:50:
[    9s] src/engine/i_system.h:76:7: note: previous declaration of ‘I_FindDataFile’ with type ‘char *(char *)’
[    9s]    76 | char* I_FindDataFile(char* file);
```

Also fixes compilation failing if `DOOM_UNIX_SYSTEM_DATADIR` macro is not defined in non-Win32 target (it is optional now)
