### PR TITLE
Adding Windows Installer for Doom64EX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,12 @@ dkms.conf
 # macOS files
 *.DS_Store
 
+# Doom 64 EX Plus Installer specific
+/Setup/Setup-cache/part*/*.cab
+/Setup/Setup-cache/part*/*.ini
+/Setup/Setup-cache/*.txt
+/Setup/Setup-SetupFiles/Doom64EX+ Setup.msi
+
 # Doom 64 EX Plus specific
 /Windows/.vs
 /Windows/Debug

--- a/Setup/Setup.aip
+++ b/Setup/Setup.aip
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<DOCUMENT Type="Advanced Installer" CreateVersion="22.3" version="22.3" Modules="simple" RootPath="." Language="en" Id="{B4723B47-1FD9-4576-996F-BFE374DEC5AF}">
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiPropsComponent">
+    <ROW Property="AI_BITMAP_DISPLAY_MODE" Value="0"/>
+    <ROW Property="AI_PRODUCTNAME_ARP" Value="Doom64EX+"/>
+    <ROW Property="AI_PROPPATH_DIR_PERBUILD_DOOM64EX.exe" Value="..\Windows\x64\Release"/>
+    <ROW Property="AI_PROPPATH_FILENAME_PERBUILD_DOOM64EX.exe" Value="DOOM64EX+.exe"/>
+    <ROW Property="AI_UNINSTALLER" Value="msiexec.exe"/>
+    <ROW Property="ALLUSERS" Value="1"/>
+    <ROW Property="ARPHELPLINK" Value="https://github.com/atsb/Doom64EX-Plus/issues"/>
+    <ROW Property="ARPNOREPAIR" Value="1"/>
+    <ROW Property="ARPPRODUCTICON" Value="doom64explus.exe" Type="8"/>
+    <ROW Property="ARPSYSTEMCOMPONENT" Value="1"/>
+    <ROW Property="ARPURLINFOABOUT" Value="https://github.com/atsb/Doom64EX-Plus/issues"/>
+    <ROW Property="ARPURLUPDATEINFO" Value="https://github.com/atsb/Doom64EX-Plus/releases"/>
+    <ROW Property="Manufacturer" Value="astb"/>
+    <ROW Property="ProductCode" Value="1033:{AED2F72F-F30A-459C-B57D-82813A3BAEB3} " Type="16"/>
+    <ROW Property="ProductLanguage" Value="1033"/>
+    <ROW Property="ProductName" Value="Doom64EX+"/>
+    <ROW Property="ProductVersion" Value="1.0.0" Options="32"/>
+    <ROW Property="SecureCustomProperties" Value="OLDPRODUCTS;AI_NEWERPRODUCTFOUND"/>
+    <ROW Property="UpgradeCode" Value="{9A9B3D46-6B5C-4BA3-AA27-395BEB7D7C47}"/>
+    <ROW Property="WindowsType9X" MultiBuildValue="DefaultBuild:Windows 9x/ME" ValueLocId="-"/>
+    <ROW Property="WindowsType9XDisplay" MultiBuildValue="DefaultBuild:Windows 9x/ME" ValueLocId="-"/>
+    <ROW Property="WindowsTypeNT" MultiBuildValue="DefaultBuild:Windows 9x/ME/NT/2000/XP/Vista/Windows 7/Windows 8 x86/Windows 8.1 x86/Windows 10 x86" ValueLocId="-"/>
+    <ROW Property="WindowsTypeNT40" MultiBuildValue="DefaultBuild:Windows NT 4.0" ValueLocId="-"/>
+    <ROW Property="WindowsTypeNT40Display" MultiBuildValue="DefaultBuild:Windows NT 4.0" ValueLocId="-"/>
+    <ROW Property="WindowsTypeNT50" MultiBuildValue="DefaultBuild:Windows 2000" ValueLocId="-"/>
+    <ROW Property="WindowsTypeNT50Display" MultiBuildValue="DefaultBuild:Windows 2000" ValueLocId="-"/>
+    <ROW Property="WindowsTypeNT5X" MultiBuildValue="DefaultBuild:Windows XP/2003" ValueLocId="-"/>
+    <ROW Property="WindowsTypeNT5XDisplay" MultiBuildValue="DefaultBuild:Windows XP/2003" ValueLocId="-"/>
+    <ROW Property="WindowsTypeNT60" MultiBuildValue="DefaultBuild:Windows Vista/Server 2008" ValueLocId="-"/>
+    <ROW Property="WindowsTypeNT60Display" MultiBuildValue="DefaultBuild:Windows Vista/Server 2008" ValueLocId="-"/>
+    <ROW Property="WindowsTypeNTDisplay" MultiBuildValue="DefaultBuild:32-bit Windows versions" ValueLocId="-"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiDirsComponent">
+    <ROW Directory="APPDIR" Directory_Parent="TARGETDIR" DefaultDir="APPDIR:." IsPseudoRoot="1" DirectoryOptions="3"/>
+    <ROW Directory="DOOM64EX_Dir" Directory_Parent="APPDIR" DefaultDir="DOOM64~1|DOOM64EX+" DirectoryOptions="3"/>
+    <ROW Directory="DesktopFolder" Directory_Parent="TARGETDIR" DefaultDir="DESKTO~1|DesktopFolder" IsPseudoRoot="1"/>
+    <ROW Directory="SHORTCUTDIR" Directory_Parent="TARGETDIR" DefaultDir="SHORTC~1|SHORTCUTDIR" IsPseudoRoot="1"/>
+    <ROW Directory="TARGETDIR" DefaultDir="SourceDir"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.SideBySideGuidComponent">
+    <ROW Component="APPDIR" Value="{156FD3D1-835F-4C90-B254-0357C2768C92}"/>
+    <ROW Component="ProductInformation" Value="{C8D5335D-6FAD-4D18-9E1C-58C467EEEA83}"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiCompsComponent">
+    <ROW Component="AI_CustomARPName" ComponentId="{388EC136-041A-47B8-98AB-2B73B9122A37}" Directory_="APPDIR" Attributes="260" KeyPath="DisplayName" Options="1"/>
+    <ROW Component="APPDIR" ComponentId="{156FD3D1-835F-4C90-B254-0357C2768C92}" Directory_="APPDIR" Attributes="0"/>
+    <ROW Component="AUTHORS" ComponentId="{2D3C1BF6-C3F6-429E-BA0E-0DECC36A832E}" Directory_="DOOM64EX_Dir" Attributes="0" KeyPath="AUTHORS" Type="0"/>
+    <ROW Component="DOOM64EX_PrimaryOutput" ComponentId="{7417E034-B397-4653-BC9D-76496A0A223D}" Directory_="DOOM64EX_Dir" Attributes="0" KeyPath="DOOM64EX.exe"/>
+    <ROW Component="ProductInformation" ComponentId="{C8D5335D-6FAD-4D18-9E1C-58C467EEEA83}" Directory_="APPDIR" Attributes="260" KeyPath="Version"/>
+    <ROW Component="SDL3.dll" ComponentId="{11FDF920-B55F-49E7-B128-C21E8D76DFE4}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="SDL3.dll"/>
+    <ROW Component="SHORTCUTDIR" ComponentId="{C7B4F1E4-7772-4D8B-BF65-D1F00D6865FD}" Directory_="SHORTCUTDIR" Attributes="0"/>
+    <ROW Component="bz2.dll" ComponentId="{A1AFAA15-304C-4896-91A6-D2DD34DB4289}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="bz2.dll"/>
+    <ROW Component="charset1.dll" ComponentId="{1D049968-8326-457E-853E-06D72622B61F}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="charset1.dll"/>
+    <ROW Component="gio2.00.dll" ComponentId="{9BDFC3DD-A9CE-4E71-A17B-213F2C367730}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="gio2.00.dll"/>
+    <ROW Component="glew32.dll" ComponentId="{BF623E2A-1B5F-4065-B900-E1A5442F7B2F}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="glew32.dll"/>
+    <ROW Component="glib2.00.dll" ComponentId="{1491A35E-167B-4642-98F2-4EFED504D196}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="glib2.00.dll"/>
+    <ROW Component="gmodule2.00.dll" ComponentId="{D707D968-0BF8-4BC6-B00E-0D68A3DA2C69}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="gmodule2.00.dll"/>
+    <ROW Component="gobject2.00.dll" ComponentId="{01EB778B-2F8B-4501-9695-EAA088CBE6F7}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="gobject2.00.dll"/>
+    <ROW Component="gthread2.00.dll" ComponentId="{F1729C9A-742C-4DBE-8EA9-CE6A70ADEF3C}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="gthread2.00.dll"/>
+    <ROW Component="iconv2.dll" ComponentId="{9D8188BA-919E-4F5A-B2A0-F0BA7815D5ED}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="iconv2.dll"/>
+    <ROW Component="intl8.dll" ComponentId="{297D2D8C-9C1D-4689-95F0-7B5A6D4E275C}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="intl8.dll"/>
+    <ROW Component="libffi.dll" ComponentId="{26800E95-A985-4FC3-8966-25B263B94F54}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="libffi.dll"/>
+    <ROW Component="libfluidsynth3.dll" ComponentId="{836F6E86-ACB0-40B9-B3C7-005093C72D6F}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="libfluidsynth3.dll"/>
+    <ROW Component="pcre216.dll" ComponentId="{03C3045C-69E9-48B9-9491-47E6E4C0F206}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="pcre216.dll"/>
+    <ROW Component="pcre232.dll" ComponentId="{A4CB1718-8CAB-4B97-A3FF-A8A7F4386EA3}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="pcre232.dll"/>
+    <ROW Component="pcre28.dll" ComponentId="{5767185D-3397-43EA-A660-5170E48B2599}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="pcre28.dll"/>
+    <ROW Component="pcre2posix.dll" ComponentId="{D2BC7E48-CCAA-4CB0-82CD-B9FF38422D46}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="pcre2posix.dll"/>
+    <ROW Component="zlib1.dll" ComponentId="{3F57C1FC-D718-4981-A706-B50F1090741E}" Directory_="DOOM64EX_Dir" Attributes="256" KeyPath="zlib1.dll"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiFeatsComponent">
+    <ROW Feature="MainFeature" Title="MainFeature" Description="Description" Display="1" Level="1" Directory_="APPDIR" Attributes="0"/>
+    <ATTRIBUTE name="CurrentFeature" value="MainFeature"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiFilesComponent">
+    <ROW File="DOOM64EX.exe" Component_="DOOM64EX_PrimaryOutput" FileName="DOOM64~2.EXE|[|AI_PROPPATH_FILENAME_PERBUILD_DOOM64EX.exe]" Version="65535.65535.65535.65535" Attributes="0" SourcePath="&lt;AI_APPPATH_PERBUILD_DOOM64EX.exe&gt;" SelfReg="false"/>
+    <ROW File="bz2.dll" Component_="bz2.dll" FileName="bz2.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\bz2.dll" SelfReg="false"/>
+    <ROW File="charset1.dll" Component_="charset1.dll" FileName="CHARSE~1.DLL|charset-1.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\charset-1.dll" SelfReg="false"/>
+    <ROW File="gio2.00.dll" Component_="gio2.00.dll" FileName="GIO-20~1.DLL|gio-2.0-0.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\gio-2.0-0.dll" SelfReg="false"/>
+    <ROW File="glew32.dll" Component_="glew32.dll" FileName="glew32.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\glew32.dll" SelfReg="false"/>
+    <ROW File="glib2.00.dll" Component_="glib2.00.dll" FileName="GLIB-2~1.DLL|glib-2.0-0.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\glib-2.0-0.dll" SelfReg="false"/>
+    <ROW File="gmodule2.00.dll" Component_="gmodule2.00.dll" FileName="GMODUL~1.DLL|gmodule-2.0-0.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\gmodule-2.0-0.dll" SelfReg="false"/>
+    <ROW File="gobject2.00.dll" Component_="gobject2.00.dll" FileName="GOBJEC~1.DLL|gobject-2.0-0.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\gobject-2.0-0.dll" SelfReg="false"/>
+    <ROW File="gthread2.00.dll" Component_="gthread2.00.dll" FileName="GTHREA~1.DLL|gthread-2.0-0.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\gthread-2.0-0.dll" SelfReg="false"/>
+    <ROW File="iconv2.dll" Component_="iconv2.dll" FileName="iconv-2.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\iconv-2.dll" SelfReg="false"/>
+    <ROW File="intl8.dll" Component_="intl8.dll" FileName="intl-8.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\intl-8.dll" SelfReg="false"/>
+    <ROW File="libffi.dll" Component_="libffi.dll" FileName="libffi.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\libffi.dll" SelfReg="false"/>
+    <ROW File="libfluidsynth3.dll" Component_="libfluidsynth3.dll" FileName="LIBFLU~1.DLL|libfluidsynth-3.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\libfluidsynth-3.dll" SelfReg="false"/>
+    <ROW File="pcre28.dll" Component_="pcre28.dll" FileName="pcre2-8.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\pcre2-8.dll" SelfReg="false"/>
+    <ROW File="pcre216.dll" Component_="pcre216.dll" FileName="pcre2-16.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\pcre2-16.dll" SelfReg="false"/>
+    <ROW File="pcre232.dll" Component_="pcre232.dll" FileName="pcre2-32.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\pcre2-32.dll" SelfReg="false"/>
+    <ROW File="pcre2posix.dll" Component_="pcre2posix.dll" FileName="PCRE2-~1.DLL|pcre2-posix.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\pcre2-posix.dll" SelfReg="false"/>
+    <ROW File="SDL3.dll" Component_="SDL3.dll" FileName="SDL3.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\SDL3.dll" SelfReg="false"/>
+    <ROW File="zlib1.dll" Component_="zlib1.dll" FileName="zlib1.dll" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\src\engine\3rdparty\Libs\x64\zlib1.dll" SelfReg="false"/>
+    <ROW File="AUTHORS" Component_="AUTHORS" FileName="AUTHORS" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\AUTHORS" SelfReg="false"/>
+    <ROW File="COPYING" Component_="AUTHORS" FileName="COPYING" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\COPYING" SelfReg="false"/>
+    <ROW File="doom64explus.wad" Component_="AUTHORS" FileName="DOOM64~1.WAD|doom64ex-plus.wad" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\doom64ex-plus.wad" SelfReg="false"/>
+    <ROW File="doomsnd.sf2" Component_="AUTHORS" FileName="doomsnd.sf2" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\doomsnd.sf2" SelfReg="false"/>
+    <ROW File="LICENSE" Component_="AUTHORS" FileName="LICENSE" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\LICENSE" SelfReg="false"/>
+    <ROW File="README.md" Component_="AUTHORS" FileName="README.md" Version="65535.65535.65535.65535" Attributes="0" SourcePath="..\README.md" SelfReg="false"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.AppPathsComponent">
+    <ROW Name="AI_APPPATH_PERBUILD_DOOM64EX.exe" Path="[|AI_PROPPATH_DIR_PERBUILD_DOOM64EX.exe]\[|AI_PROPPATH_FILENAME_PERBUILD_DOOM64EX.exe]" Type="2" Content="0"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.BuildComponent">
+    <ROW BuildKey="DefaultBuild" BuildName="Build" BuildOrder="1" BuildType="0" PackageFileName="Doom64EX+ Setup" Languages="en" InstallationType="4" SummInfoMetadata="Page Count:450" UseLargeSchema="true" MsiPackageType="x64"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.DictionaryComponent">
+    <ROW Path="&lt;AI_DICTS&gt;ui.ail"/>
+    <ROW Path="&lt;AI_DICTS&gt;ui_en.ail"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.FragmentComponent">
+    <ROW Fragment="CommonUI.aip" Path="&lt;AI_FRAGS&gt;CommonUI.aip"/>
+    <ROW Fragment="FolderDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\FolderDlg.aip"/>
+    <ROW Fragment="MaintenanceTypeDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\MaintenanceTypeDlg.aip"/>
+    <ROW Fragment="MaintenanceWelcomeDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\MaintenanceWelcomeDlg.aip"/>
+    <ROW Fragment="SequenceDialogs.aip" Path="&lt;AI_THEMES&gt;classic\fragments\SequenceDialogs.aip"/>
+    <ROW Fragment="Sequences.aip" Path="&lt;AI_FRAGS&gt;Sequences.aip"/>
+    <ROW Fragment="StaticUIStrings.aip" Path="&lt;AI_FRAGS&gt;StaticUIStrings.aip"/>
+    <ROW Fragment="Themes.aip" Path="&lt;AI_FRAGS&gt;Themes.aip"/>
+    <ROW Fragment="UI.aip" Path="&lt;AI_THEMES&gt;classic\fragments\UI.aip"/>
+    <ROW Fragment="Validation.aip" Path="&lt;AI_FRAGS&gt;Validation.aip"/>
+    <ROW Fragment="VerifyRemoveDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\VerifyRemoveDlg.aip"/>
+    <ROW Fragment="VerifyRepairDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\VerifyRepairDlg.aip"/>
+    <ROW Fragment="WelcomeDlg.aip" Path="&lt;AI_THEMES&gt;classic\fragments\WelcomeDlg.aip"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiBinaryComponent">
+    <ROW Name="aicustact.dll" SourcePath="&lt;AI_CUSTACTS&gt;aicustact.dll"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiControlEventComponent">
+    <ROW Dialog_="WelcomeDlg" Control_="Next" Event="NewDialog" Argument="FolderDlg" Condition="AI_INSTALL" Ordering="1"/>
+    <ROW Dialog_="FolderDlg" Control_="Next" Event="NewDialog" Argument="VerifyReadyDlg" Condition="AI_INSTALL" Ordering="201"/>
+    <ROW Dialog_="FolderDlg" Control_="Back" Event="NewDialog" Argument="WelcomeDlg" Condition="AI_INSTALL" Ordering="1"/>
+    <ROW Dialog_="MaintenanceWelcomeDlg" Control_="Next" Event="NewDialog" Argument="MaintenanceTypeDlg" Condition="AI_MAINT" Ordering="99"/>
+    <ROW Dialog_="VerifyReadyDlg" Control_="Install" Event="EndDialog" Argument="Return" Condition="AI_MAINT" Ordering="198"/>
+    <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="CustomizeDlg" Condition="AI_MAINT" Ordering="202"/>
+    <ROW Dialog_="VerifyReadyDlg" Control_="Install" Event="EndDialog" Argument="Return" Condition="AI_INSTALL" Ordering="197"/>
+    <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="FolderDlg" Condition="AI_INSTALL" Ordering="201"/>
+    <ROW Dialog_="CustomizeDlg" Control_="Next" Event="NewDialog" Argument="VerifyReadyDlg" Condition="AI_MAINT" Ordering="101"/>
+    <ROW Dialog_="CustomizeDlg" Control_="Back" Event="NewDialog" Argument="MaintenanceTypeDlg" Condition="AI_MAINT" Ordering="1"/>
+    <ROW Dialog_="MaintenanceTypeDlg" Control_="ChangeButton" Event="NewDialog" Argument="CustomizeDlg" Condition="AI_MAINT" Ordering="501"/>
+    <ROW Dialog_="MaintenanceTypeDlg" Control_="Back" Event="NewDialog" Argument="MaintenanceWelcomeDlg" Condition="AI_MAINT" Ordering="1"/>
+    <ROW Dialog_="MaintenanceTypeDlg" Control_="RemoveButton" Event="NewDialog" Argument="VerifyRemoveDlg" Condition="AI_MAINT AND InstallMode=&quot;Remove&quot;" Ordering="601"/>
+    <ROW Dialog_="VerifyRemoveDlg" Control_="Back" Event="NewDialog" Argument="MaintenanceTypeDlg" Condition="AI_MAINT AND InstallMode=&quot;Remove&quot;" Ordering="1"/>
+    <ROW Dialog_="MaintenanceTypeDlg" Control_="RepairButton" Event="NewDialog" Argument="VerifyRepairDlg" Condition="AI_MAINT AND InstallMode=&quot;Repair&quot;" Ordering="601"/>
+    <ROW Dialog_="VerifyRepairDlg" Control_="Back" Event="NewDialog" Argument="MaintenanceTypeDlg" Condition="AI_MAINT AND InstallMode=&quot;Repair&quot;" Ordering="1"/>
+    <ROW Dialog_="VerifyRepairDlg" Control_="Repair" Event="EndDialog" Argument="Return" Condition="AI_MAINT AND InstallMode=&quot;Repair&quot;" Ordering="399" Options="1"/>
+    <ROW Dialog_="VerifyRemoveDlg" Control_="Remove" Event="EndDialog" Argument="Return" Condition="AI_MAINT AND InstallMode=&quot;Remove&quot;" Ordering="299" Options="1"/>
+    <ROW Dialog_="PatchWelcomeDlg" Control_="Next" Event="NewDialog" Argument="VerifyReadyDlg" Condition="AI_PATCH" Ordering="201"/>
+    <ROW Dialog_="ResumeDlg" Control_="Install" Event="EndDialog" Argument="Return" Condition="AI_RESUME" Ordering="299"/>
+    <ROW Dialog_="VerifyReadyDlg" Control_="Install" Event="EndDialog" Argument="Return" Condition="AI_PATCH" Ordering="199"/>
+    <ROW Dialog_="VerifyReadyDlg" Control_="Back" Event="NewDialog" Argument="PatchWelcomeDlg" Condition="AI_PATCH" Ordering="203"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiCreateFolderComponent">
+    <ROW Directory_="APPDIR" Component_="APPDIR" ManualDelete="true"/>
+    <ROW Directory_="SHORTCUTDIR" Component_="SHORTCUTDIR" ManualDelete="false"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiCustActComponent">
+    <ROW Action="AI_DOWNGRADE" Type="19" Target="4010"/>
+    <ROW Action="AI_DpiContentScale" Type="1" Source="aicustact.dll" Target="DpiContentScale"/>
+    <ROW Action="AI_EnableDebugLog" Type="321" Source="aicustact.dll" Target="EnableDebugLog"/>
+    <ROW Action="AI_GetArpIconPath" Type="1" Source="aicustact.dll" Target="GetArpIconPath"/>
+    <ROW Action="AI_InstallModeCheck" Type="1" Source="aicustact.dll" Target="UpdateInstallMode" WithoutSeq="true"/>
+    <ROW Action="AI_PREPARE_UPGRADE" Type="65" Source="aicustact.dll" Target="PrepareUpgrade"/>
+    <ROW Action="AI_PRESERVE_INSTALL_TYPE" Type="65" Source="aicustact.dll" Target="PreserveInstallType"/>
+    <ROW Action="AI_RESTORE_LOCATION" Type="65" Source="aicustact.dll" Target="RestoreLocation"/>
+    <ROW Action="AI_ResolveKnownFolders" Type="1" Source="aicustact.dll" Target="AI_ResolveKnownFolders"/>
+    <ROW Action="AI_SHOW_LOG" Type="65" Source="aicustact.dll" Target="LaunchLogFile" WithoutSeq="true"/>
+    <ROW Action="AI_STORE_LOCATION" Type="51" Source="ARPINSTALLLOCATION" Target="[APPDIR]"/>
+    <ROW Action="SET_APPDIR" Type="307" Source="APPDIR" Target="[ProgramFilesFolder][Manufacturer]\[ProductName]" MultiBuildTarget="DefaultBuild:[ProgramFiles64Folder]"/>
+    <ROW Action="SET_SHORTCUTDIR" Type="307" Source="SHORTCUTDIR" Target="[ProgramMenuFolder][ProductName]"/>
+    <ROW Action="SET_TARGETDIR_TO_APPDIR" Type="51" Source="TARGETDIR" Target="[APPDIR]"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiFeatCompsComponent">
+    <ROW Feature_="MainFeature" Component_="APPDIR"/>
+    <ROW Feature_="MainFeature" Component_="ProductInformation"/>
+    <ROW Feature_="MainFeature" Component_="DOOM64EX_PrimaryOutput"/>
+    <ROW Feature_="MainFeature" Component_="SHORTCUTDIR"/>
+    <ROW Feature_="MainFeature" Component_="AI_CustomARPName"/>
+    <ROW Feature_="MainFeature" Component_="bz2.dll"/>
+    <ROW Feature_="MainFeature" Component_="charset1.dll"/>
+    <ROW Feature_="MainFeature" Component_="gio2.00.dll"/>
+    <ROW Feature_="MainFeature" Component_="glew32.dll"/>
+    <ROW Feature_="MainFeature" Component_="glib2.00.dll"/>
+    <ROW Feature_="MainFeature" Component_="gmodule2.00.dll"/>
+    <ROW Feature_="MainFeature" Component_="gobject2.00.dll"/>
+    <ROW Feature_="MainFeature" Component_="gthread2.00.dll"/>
+    <ROW Feature_="MainFeature" Component_="iconv2.dll"/>
+    <ROW Feature_="MainFeature" Component_="intl8.dll"/>
+    <ROW Feature_="MainFeature" Component_="libffi.dll"/>
+    <ROW Feature_="MainFeature" Component_="libfluidsynth3.dll"/>
+    <ROW Feature_="MainFeature" Component_="pcre28.dll"/>
+    <ROW Feature_="MainFeature" Component_="pcre216.dll"/>
+    <ROW Feature_="MainFeature" Component_="pcre232.dll"/>
+    <ROW Feature_="MainFeature" Component_="pcre2posix.dll"/>
+    <ROW Feature_="MainFeature" Component_="SDL3.dll"/>
+    <ROW Feature_="MainFeature" Component_="zlib1.dll"/>
+    <ROW Feature_="MainFeature" Component_="AUTHORS"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiIconsComponent">
+    <ROW Name="doom64explus.exe" SourcePath="..\src\engine\doom64ex-plus.ico" Index="0"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiInstExSeqComponent">
+    <ROW Action="AI_DOWNGRADE" Condition="AI_NEWERPRODUCTFOUND AND (UILevel &lt;&gt; 5)" Sequence="210"/>
+    <ROW Action="AI_RESTORE_LOCATION" Condition="APPDIR=&quot;&quot;" Sequence="749"/>
+    <ROW Action="AI_STORE_LOCATION" Condition="(Not Installed) OR REINSTALL" Sequence="1501"/>
+    <ROW Action="AI_PREPARE_UPGRADE" Condition="AI_UPGRADE=&quot;No&quot; AND (Not Installed)" Sequence="1399"/>
+    <ROW Action="AI_ResolveKnownFolders" Sequence="52"/>
+    <ROW Action="AI_EnableDebugLog" Sequence="51"/>
+    <ROW Action="AI_GetArpIconPath" Sequence="1401"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiInstallUISequenceComponent">
+    <ROW Action="AI_PRESERVE_INSTALL_TYPE" Sequence="199"/>
+    <ROW Action="AI_RESTORE_LOCATION" Condition="APPDIR=&quot;&quot;" Sequence="749"/>
+    <ROW Action="AI_ResolveKnownFolders" Sequence="53"/>
+    <ROW Action="AI_DpiContentScale" Sequence="52"/>
+    <ROW Action="AI_EnableDebugLog" Sequence="51"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiLaunchConditionsComponent">
+    <ROW Condition="( Version9X OR VersionNT64 )" Description="[ProductName] cannot be installed on [WindowsTypeNTDisplay]." DescriptionLocId="AI.LaunchCondition.NoNT" IsPredefined="true" Builds="DefaultBuild"/>
+    <ROW Condition="((VersionNT &lt;&gt; 501) AND (VersionNT &lt;&gt; 502))" Description="[ProductName] cannot be installed on [WindowsTypeNT5XDisplay]." DescriptionLocId="AI.LaunchCondition.NoNT5X" IsPredefined="true" Builds="DefaultBuild"/>
+    <ROW Condition="(VersionNT &lt;&gt; 400)" Description="[ProductName] cannot be installed on [WindowsTypeNT40Display]." DescriptionLocId="AI.LaunchCondition.NoNT40" IsPredefined="true" Builds="DefaultBuild"/>
+    <ROW Condition="(VersionNT &lt;&gt; 500)" Description="[ProductName] cannot be installed on [WindowsTypeNT50Display]." DescriptionLocId="AI.LaunchCondition.NoNT50" IsPredefined="true" Builds="DefaultBuild"/>
+    <ROW Condition="(VersionNT &lt;&gt; 600)" Description="[ProductName] cannot be installed on [WindowsTypeNT60Display]." DescriptionLocId="AI.LaunchCondition.NoNT60" IsPredefined="true" Builds="DefaultBuild"/>
+    <ROW Condition="VersionNT" Description="[ProductName] cannot be installed on [WindowsType9XDisplay]." DescriptionLocId="AI.LaunchCondition.No9X" IsPredefined="true" Builds="DefaultBuild"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiRegsComponent">
+    <ROW Registry="Comments" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="Comments" Value="[ARPCOMMENTS]" Component_="AI_CustomARPName"/>
+    <ROW Registry="Contact" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="Contact" Value="[ARPCONTACT]" Component_="AI_CustomARPName"/>
+    <ROW Registry="CurrentVersion" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion" Name="\"/>
+    <ROW Registry="DisplayIcon" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="DisplayIcon" Value="[ARP_ICON_PATH]" Component_="AI_CustomARPName"/>
+    <ROW Registry="DisplayName" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="DisplayName" Value="[AI_PRODUCTNAME_ARP]" Component_="AI_CustomARPName"/>
+    <ROW Registry="DisplayVersion" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="DisplayVersion" Value="[ProductVersion]" Component_="AI_CustomARPName"/>
+    <ROW Registry="EstimatedSize" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="EstimatedSize" Value="#[AI_ARP_SIZE]" Component_="AI_CustomARPName" VirtualValue="#"/>
+    <ROW Registry="HelpLink" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="HelpLink" Value="[ARPHELPLINK]" Component_="AI_CustomARPName"/>
+    <ROW Registry="HelpTelephone" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="HelpTelephone" Value="[ARPHELPTELEPHONE]" Component_="AI_CustomARPName"/>
+    <ROW Registry="InstallLocation" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="InstallLocation" Value="[APPDIR]" Component_="AI_CustomARPName"/>
+    <ROW Registry="Manufacturer" Root="-1" Key="Software\[Manufacturer]" Name="\"/>
+    <ROW Registry="Microsoft" Root="-1" Key="Software\Microsoft" Name="\"/>
+    <ROW Registry="ModifyPath" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="ModifyPath" Value="[AI_UNINSTALLER] /i [ProductCode] AI_UNINSTALLER_CTP=1" Component_="AI_CustomARPName"/>
+    <ROW Registry="NoRepair" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="NoRepair" Value="#1" Component_="AI_CustomARPName" VirtualValue="#"/>
+    <ROW Registry="Path" Root="-1" Key="Software\[Manufacturer]\[ProductName]" Name="Path" Value="[APPDIR]" Component_="ProductInformation"/>
+    <ROW Registry="ProductName" Root="-1" Key="Software\[Manufacturer]\[ProductName]" Name="\"/>
+    <ROW Registry="ProductNameProductVersion" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="\"/>
+    <ROW Registry="Publisher" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="Publisher" Value="[Manufacturer]" Component_="AI_CustomARPName"/>
+    <ROW Registry="Readme" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="Readme" Value="[ARPREADME]" Component_="AI_CustomARPName"/>
+    <ROW Registry="Software" Root="-1" Key="Software" Name="\"/>
+    <ROW Registry="URLInfoAbout" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="URLInfoAbout" Value="[ARPURLINFOABOUT]" Component_="AI_CustomARPName"/>
+    <ROW Registry="URLUpdateInfo" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="URLUpdateInfo" Value="[ARPURLUPDATEINFO]" Component_="AI_CustomARPName"/>
+    <ROW Registry="Uninstall" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall" Name="\"/>
+    <ROW Registry="UninstallPath" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="UninstallPath" Value="[AI_UNINSTALLER] /x [ProductCode] AI_UNINSTALLER_CTP=1" Component_="AI_CustomARPName"/>
+    <ROW Registry="UninstallString" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="UninstallString" Value="[AI_UNINSTALLER] /x [ProductCode] AI_UNINSTALLER_CTP=1" Component_="AI_CustomARPName"/>
+    <ROW Registry="Version" Root="-1" Key="Software\[Manufacturer]\[ProductName]" Name="Version" Value="[ProductVersion]" Component_="ProductInformation"/>
+    <ROW Registry="VersionMajor" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="VersionMajor" Value="#1" Component_="AI_CustomARPName" VirtualValue="#"/>
+    <ROW Registry="VersionMinor" Root="-1" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName] [ProductVersion]" Name="VersionMinor" Value="#0" Component_="AI_CustomARPName" VirtualValue="#"/>
+    <ROW Registry="Windows" Root="-1" Key="Software\Microsoft\Windows" Name="\"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiShortsComponent">
+    <ROW Shortcut="DOOM64EX" Directory_="SHORTCUTDIR" Name="DOOM64~1|DOOM64EX+" Component_="DOOM64EX_PrimaryOutput" Target="[#DOOM64EX.exe]" Hotkey="0" IconIndex="0" ShowCmd="1"/>
+    <ROW Shortcut="DOOM64EX_1" Directory_="DesktopFolder" Name="DOOM64~1|DOOM64EX+" Component_="DOOM64EX_PrimaryOutput" Target="[#DOOM64EX.exe]" Hotkey="0" IconIndex="0" ShowCmd="1"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiThemeComponent">
+    <ATTRIBUTE name="UsedTheme" value="classic"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.MsiUpgradeComponent">
+    <ROW UpgradeCode="[|UpgradeCode]" VersionMin="0.0.1" VersionMax="[|ProductVersion]" Attributes="257" ActionProperty="OLDPRODUCTS"/>
+    <ROW UpgradeCode="[|UpgradeCode]" VersionMin="[|ProductVersion]" Attributes="2" ActionProperty="AI_NEWERPRODUCTFOUND"/>
+  </COMPONENT>
+  <COMPONENT cid="caphyon.advinst.msicomp.VsProjectComponent">
+    <ROW ProjectId="{f7595469-0b54-4529-b8fd-b73f4c061494}" ProjectName="DOOM64EX+" OutputGroup="PrimaryOutput" OutputFile="DOOM64EX.exe" OutputFileShortcut="DOOM64EX"/>
+  </COMPONENT>
+</DOCUMENT>

--- a/Setup/Setup.aiproj
+++ b/Setup/Setup.aiproj
@@ -1,0 +1,45 @@
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">All</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>d41c0e6b-1723-4f6b-a0db-31dd5716efe1</ProjectGuid>
+    <OutputType>msi</OutputType>
+    <ProjectHome>.</ProjectHome>
+    <StartupFile>Setup.aip</StartupFile>
+    <SearchPath>
+    </SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <IsWindowsApplication>True</IsWindowsApplication>
+    <AssemblyName>Setup</AssemblyName>
+    <Name>Setup</Name>
+    <RootNamespace>Setup</RootNamespace>
+    <LoadFromTemplate>
+    </LoadFromTemplate>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Build' " />
+  <ItemGroup>
+    <Compile Include="Setup.aip">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Windows\Doom64EX+.vcxproj">
+      <Name>DOOM64EX+</Name>
+      <Project>{f7595469-0b54-4529-b8fd-b73f4c061494}</Project>
+      <Private>True</Private>
+      <OutputsToImport>PrimaryOutput</OutputsToImport>
+    </ProjectReference>
+  </ItemGroup>
+  <Target Name="Build">
+    <Error Text="This project requires Advanced Installer tool. Please download it from https://www.advancedinstaller.com/download.html" />
+  </Target>
+  <Target Name="Rebuild">
+    <Error Text="This project requires Advanced Installer tool. Please download it from https://www.advancedinstaller.com/download.html" />
+  </Target>
+  <Target Name="Clean">
+  </Target>
+  <Target Name="ResolveAssemblyReferences">
+  </Target>
+  <Import Condition="'$(AdvancedInstallerMSBuildTargets)' != ''" Project="$(AdvancedInstallerMSBuildTargets)\AdvInstExtTasks.Targets" />
+  <Import Condition="('$(AdvancedInstallerMSBuildTargets)' == '') And (Exists('$(MSBuildExtensionsPath32)\Caphyon\Advanced Installer\AdvInstExtTasks.Targets'))" Project="$(MSBuildExtensionsPath32)\Caphyon\Advanced Installer\AdvInstExtTasks.Targets" />
+</Project>

--- a/Windows/Doom64EX+.sln
+++ b/Windows/Doom64EX+.sln
@@ -1,9 +1,11 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.3.32922.545
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DOOM64EX+", "Doom64EX+.vcxproj", "{F7595469-0B54-4529-B8FD-B73F4C061494}"
+EndProject
+Project("{840C416C-B8F3-42BC-B0DD-F6BB14C9F8CB}") = "Setup", "..\Setup\Setup.aiproj", "{D41C0E6B-1723-4F6B-A0DB-31DD5716EFE1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{F7595469-0B54-4529-B8FD-B73F4C061494}.Debug|x64.Build.0 = Debug|x64
 		{F7595469-0B54-4529-B8FD-B73F4C061494}.Release|x64.ActiveCfg = Release|x64
 		{F7595469-0B54-4529-B8FD-B73F4C061494}.Release|x64.Build.0 = Release|x64
+		{D41C0E6B-1723-4F6B-A0DB-31DD5716EFE1}.Debug|x64.ActiveCfg = Build
+		{D41C0E6B-1723-4F6B-A0DB-31DD5716EFE1}.Debug|x64.Build.0 = Build
+		{D41C0E6B-1723-4F6B-A0DB-31DD5716EFE1}.Release|x64.ActiveCfg = Build
+		{D41C0E6B-1723-4F6B-A0DB-31DD5716EFE1}.Release|x64.Build.0 = Build
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Windows/Doom64EX+.vcxproj
+++ b/Windows/Doom64EX+.vcxproj
@@ -72,7 +72,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <GenerateManifest>false</GenerateManifest>
+    <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -148,6 +148,7 @@
       <AdditionalDependencies>opengl32.lib;bz2.lib;gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;gthread-2.0.lib;charset.lib;iconv.lib;libffi.lib;fluidsynth.lib;glib-2.0.lib;intl.lib;pcre2-8.lib;pcre2-16.lib;pcre2-32.lib;pcre2-posix.lib;zlib.lib;libpng16.lib;SDL3.lib;wsock32.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
       <LinkErrorReporting>NoErrorReport</LinkErrorReporting>
       <OptimizeReferences>true</OptimizeReferences>
+      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Created an Installer Program for Doom64EX+

All is needed is 
1. [Advanced Installer for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=caphyon.AdvancedInstallerforVisualStudio2022)
2. [Advanced Installer](https://www.advancedinstaller.com/download.html)

To ensure proper functionality, I configured Doom64EX+ to run with Administrator privileges so the executable can run from the Program Files folder. All the necessary files for installation are already prepared to be placed in the Program Files folder. The only additional files required are d64.deh and official_pwads/DOOM64_ALPHA.wad.

If necessary, I can use a different Visual Studio installer extension to complete the installation process.

Here's the setup executable if you want to test it out: 
[Doom64EX+ Setup.zip](https://github.com/user-attachments/files/18462671/Doom64EX%2B.Setup.zip)
