### PR TITLE
Don't override system provided CC in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC=gcc
+CC ?= gcc
 
 libs := sdl3 libpng gl glu fluidsynth
 


### PR DESCRIPTION
Otherwise, if the CC environment variable is already set it is ignored in favor of the hardcoded gcc.