### PR TITLE
Fix stack buffer overflow

### DIFF
--- a/src/engine/sc_main.c
+++ b/src/engine/sc_main.c
@@ -171,7 +171,7 @@ static int SC_SetData(void* data, const scdatatable_t* table) {
 				*(int*)pointer = sc_parser.getint();
 				break;
 			case 'b':
-				*(int*)pointer = true;
+				*(boolean*)pointer = true;
 				break;
 			case 'c':
 				sc_parser.compare("="); // expect a '='


### PR DESCRIPTION
This caused a crash on startup on Linux with NVIDIA GPU drivers

This was caught compiling with `-fsanitize=address -fno-omit-frame-pointer` to investigate
a subsequent NVIDIA crash in a different unrelated part of the program:

```
==102969==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7b1deda013b9 at pc 0x0000004497fb bp 0x7fff0e4e32e0 sp 0x7fff0e4e32d8
WRITE of size 4 at 0x7b1deda013b9 thread T0
    #0 0x0000004497fa in SC_SetData (/home/bobbie/git_projects/Doom64EX-Plus/DOOM64EX-Plus+0x4497fa) (BuildId: 484da7651c18382620d7bb02fd096af83bd5ab90)
    #1 0x000000489681 in P_InitPicAnims (/home/bobbie/git_projects/Doom64EX-Plus/DOOM64EX-Plus+0x489681) (BuildId: 484da7651c18382620d7bb02fd096af83bd5ab90)
    #2 0x000000487277 in P_Init (/home/bobbie/git_projects/Doom64EX-Plus/DOOM64EX-Plus+0x487277) (BuildId: 484da7651c18382620d7bb02fd096af83bd5ab90)
    #3 0x00000041362e in D_DoomMain (/home/bobbie/git_projects/Doom64EX-Plus/DOOM64EX-Plus+0x41362e) (BuildId: 484da7651c18382620d7bb02fd096af83bd5ab90)
    #4 0x0000004b4056 in main (/home/bobbie/git_projects/Doom64EX-Plus/DOOM64EX-Plus+0x4b4056) (BuildId: 484da7651c18382620d7bb02fd096af83bd5ab90)
    #5 0x7f1df0e2b12d in __libc_start_call_main (/lib64/libc.so.6+0x2b12d) (BuildId: 4e306825df357f9b661479a3f9d24a8dbf960c1f)
    #6 0x7f1df0e2b1f8 in __libc_start_main_impl (/lib64/libc.so.6+0x2b1f8) (BuildId: 4e306825df357f9b661479a3f9d24a8dbf960c1f)
    #7 0x000000405f24 in _start ../sysdeps/x86_64/start.S:115

Address 0x7b1deda013b9 is located in stack of thread T0 at offset 57 in frame
    #0 0x0000004894e9 in P_InitPicAnims (/home/bobbie/git_projects/Doom64EX-Plus/DOOM64EX-Plus+0x4894e9) (BuildId: 484da7651c18382620d7bb02fd096af83bd5ab90)

  This frame has 1 object(s):
    [32, 60) 'anim' (line 100) <== Memory access at offset 57 partially overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)

```

