### PR TITLE
Audio fixes

### DIFF
--- a/src/engine/i_audio.c
+++ b/src/engine/i_audio.c
@@ -309,7 +309,7 @@ typedef int(*signalhandler)(doomseq_t*);
 
 static void FMOD_ERROR_CHECK(FMOD_RESULT result) {
     if (result != FMOD_OK) {
-        printf("FMOD Studio: %s", FMOD_ErrorString(result));
+        printf("FMOD Studio: %s\n", FMOD_ErrorString(result));
     }
 }
 
@@ -1740,7 +1740,7 @@ int FMOD_StartMusic(int mus_id) {
             return mus_id;
         }
         else {
-            CON_Printf("FMOD_StartMusic: Failed to play pre-rendered track for mus_id %d.\n", mus_id);
+            CON_Warnf("FMOD_StartMusic: Failed to play pre-rendered track for mus_id %d.\n", mus_id);
             sound.fmod_studio_channel_music = NULL; // channel is null on failure
             return -1;
         }
@@ -1773,7 +1773,7 @@ int FMOD_StartMusic(int mus_id) {
                 return mus_id;
             }
             else {
-                CON_Printf("FMOD_StartMusic: Failed to play MIDI sound for mus_id %d after creation.\n", mus_id);
+                CON_Warnf("FMOD_StartMusic: Failed to play MIDI sound for mus_id %d after creation.\n", mus_id);
                 FMOD_ERROR_CHECK(FMOD_Sound_Release(currentMidiSound));
                 currentMidiSound = NULL;
                 sound.fmod_studio_channel_music = NULL;
@@ -1781,7 +1781,7 @@ int FMOD_StartMusic(int mus_id) {
             }
         }
         else {
-            CON_Printf("FMOD_StartMusic: Failed to create MIDI sound for mus_id %d. Result: %d\n", mus_id, result);
+            CON_Warnf("FMOD_StartMusic: Failed to create MIDI sound for mus_id %d. Result: %d\n", mus_id, result);
             if (currentMidiSound) {
                 FMOD_ERROR_CHECK(FMOD_Sound_Release(currentMidiSound));
                 currentMidiSound = NULL;
@@ -1791,13 +1791,13 @@ int FMOD_StartMusic(int mus_id) {
     }
     else {
         if (mus_id >= 0 && mus_id < MAX_FMOD_MUSIC_TRACKS && sound.fmod_studio_music[mus_id] == NULL) {
-            CON_Printf("FMOD_StartMusic: Pre-rendered track for mus_id %d is NULL (and not a MIDI).\n", mus_id);
+            CON_Warnf("FMOD_StartMusic: Pre-rendered track for mus_id %d is NULL (and not a MIDI).\n", mus_id);
         }
         else if (mus_id >= 0 && mus_id < doomseq.nsongs && doomseq.songs[mus_id].data == NULL) {
-            CON_Printf("FMOD_StartMusic: MIDI track data for mus_id %d is NULL (and not pre-rendered).\n", mus_id);
+            CON_Warnf("FMOD_StartMusic: MIDI track data for mus_id %d is NULL (and not pre-rendered).\n", mus_id);
         }
         else {
-            CON_Printf("FMOD_StartMusic: mus_id %d is out of bounds or invalid.\n", mus_id);
+            CON_Warnf("FMOD_StartMusic: mus_id %d is out of bounds or invalid.\n", mus_id);
         }
         return -1;
     }

--- a/src/engine/i_audio.c
+++ b/src/engine/i_audio.c
@@ -1222,7 +1222,7 @@ void I_InitSequencer(void) {
     char* sfpath;
     void* extradriverdata = 0;
 
-    I_Printf("Audio Engine: FMOD Studio by Firelight Technologies Pty Ltd.\n\n");
+    I_Printf("Audio Engine: FMOD Studio by Firelight Technologies Pty Ltd.\n");
 
     FMOD_ERROR_CHECK(FMOD_System_Create(&sound.fmod_studio_system, FMOD_VERSION));
     FMOD_ERROR_CHECK(FMOD_System_Create(&sound.fmod_studio_system_music, FMOD_VERSION));

--- a/src/engine/i_audio.h
+++ b/src/engine/i_audio.h
@@ -51,7 +51,7 @@ typedef struct {
 
 // FMOD Studio
 
-#define MAX_GAME_SFX 93
+#define MAX_GAME_SFX 256
 #define MAX_FMOD_MUSIC_TRACKS 138
 
 struct Sound {

--- a/src/engine/i_audio.h
+++ b/src/engine/i_audio.h
@@ -48,14 +48,19 @@ typedef struct {
     fixed_t z;
 } sndsrc_t;
 
+
 // FMOD Studio
+
+#define MAX_GAME_SFX 93
+#define MAX_FMOD_MUSIC_TRACKS 138
+
 struct Sound {
     FMOD_SYSTEM* fmod_studio_system;
     FMOD_SYSTEM* fmod_studio_system_music;
 
-    FMOD_SOUND* fmod_studio_sound[93];
-    FMOD_SOUND* fmod_studio_sound_plasma[93];
-    FMOD_SOUND* fmod_studio_music[138];
+    FMOD_SOUND* fmod_studio_sound[MAX_GAME_SFX];
+    //FMOD_SOUND* fmod_studio_sound_plasma[MAX_GAME_SFX];
+    FMOD_SOUND* fmod_studio_music[MAX_FMOD_MUSIC_TRACKS];
 
     FMOD_CHANNEL* fmod_studio_channel;
     FMOD_CHANNEL* fmod_studio_channel_music;


### PR DESCRIPTION
Various audio fixes.
A few of them being FMOD_ERROR_CHECK error messages printed on stdout.
Tested on Linux.

`FMOD_StopSound()` and anything that accesses `sound.fmod_studio_channel` does not work because that field is never initialized.