### PR TITLE
Fix sequenceGlow_t not being correctly read from save

### DIFF
--- a/src/engine/p_saveg.c
+++ b/src/engine/p_saveg.c
@@ -814,7 +814,7 @@ static void saveg_read_sequenceGlow_t(void* data) {
     sequenceGlow_t* seq = (sequenceGlow_t*)data;
     seq->sector = &sectors[saveg_read32()];
     int pos = saveg_read32();
-    seq->headsector = pos == 0 ? NULL: &sectors[pos-1];
+    seq->headsector = pos > 0 ? &sectors[pos - 1] : NULL;
     seq->count = saveg_read32();
     seq->start = saveg_read32();
     seq->index = saveg_read32();

--- a/src/engine/p_saveg.c
+++ b/src/engine/p_saveg.c
@@ -813,7 +813,8 @@ static void saveg_write_sequenceGlow_t(void* data) {
 static void saveg_read_sequenceGlow_t(void* data) {
     sequenceGlow_t* seq = (sequenceGlow_t*)data;
     seq->sector = &sectors[saveg_read32()];
-    seq->headsector = &sectors[saveg_read32() - 1];
+    int pos = saveg_read32();
+    seq->headsector = pos == 0 ? NULL: &sectors[pos-1];
     seq->count = saveg_read32();
     seq->start = saveg_read32();
     seq->index = saveg_read32();


### PR DESCRIPTION
It was wrecking havoc in `T_Sequence()` function on save load, causing heap buffer overflow in that function and weird visual lighting glitches on save load

Fixes #309 