### PR TITLE
Fix a graphical glitch when pressing "Apply Settings" in the "Video" menu with accessibility mode enabled

### DIFF
--- a/src/engine/st_stuff.c
+++ b/src/engine/st_stuff.c
@@ -482,10 +482,9 @@ void ST_FlashingScreen(byte r, byte g, byte b, byte a) {
 		dglDisable(GL_TEXTURE_2D);
 		dglColor4ubv((byte*)&c);
 		dglRecti(SCREENWIDTH, SCREENHEIGHT, 0, 0);
-		dglEnable(GL_TEXTURE_2D);
-
 		GL_SetState(GLSTATE_BLEND, 0);
 	}
+	dglEnable(GL_TEXTURE_2D);
 }
 
 //


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/7f979256-89a7-42d4-bf72-0faf30ba696c

After:

https://github.com/user-attachments/assets/4fd843c9-dce0-4e4c-a302-5b188b58d3d7

