### PR TITLE
Remove unneeded s_driver console variable

### DIFF
--- a/src/engine/i_audio.c
+++ b/src/engine/i_audio.c
@@ -87,43 +87,8 @@ CVAR_EXTERNAL(s_sfxvol);
 CVAR_EXTERNAL(s_musvol);
 static FMOD_SOUND* currentMidiSound = NULL;
 
-// 20120203 villsa - cvar for audio driver
-#ifdef _WIN32
-CVAR_CMD(s_driver, dsound)
-#elif __linux__
-CVAR_CMD(s_driver, alsa)
-#elif __APPLE__
-CVAR_CMD(s_driver, coreaudio)
-#else
-CVAR_CMD(s_driver, sndio)
-#endif
-{
-    char* driver = cvar->string;
-
-    if (!dstrcmp(driver, "jack") ||
-        !dstrcmp(driver, "alsa") ||
-        !dstrcmp(driver, "oss") ||
-        !dstrcmp(driver, "pulseaudio") ||
-        !dstrcmp(driver, "coreaudio") ||
-        !dstrcmp(driver, "dsound") ||
-        !dstrcmp(driver, "portaudio") ||
-        !dstrcmp(driver, "sndio") ||
-        !dstrcmp(driver, "sndman") ||
-        !dstrcmp(driver, "dart") ||
-        !dstrcmp(driver, "file")
-        ) {
-        return;
-    }
-
-    CON_Warnf("Invalid driver name\n");
-    CON_Warnf("Valid driver names: jack, alsa, oss, pulseaudio, coreaudio, dsound, portaudio, sndio, sndman, dart, file\n");
-    CON_CvarSet(cvar->name, DEFAULT_FLUID_DRIVER);
-}
-
 struct Sound sound;
 struct Reverb fmod_reverb;
-
-
 
 // FMOD Studio
 static float INCHES_PER_METER = 39.3701f;

--- a/src/engine/i_audio.h
+++ b/src/engine/i_audio.h
@@ -28,20 +28,6 @@
 #include <fmod_errors.h>
 #include "m_fixed.h"
 
-// 20120107 bkw: Linux users can change the default FluidSynth backend here:
-#ifndef _WIN32
-#define DEFAULT_FLUID_DRIVER "sndio"
-
-// 20120203 villsa: add default for windows
-#define DEFAULT_FLUID_DRIVER "dsound"
-#elif __linux__
-#define DEFAULT_FLUID_DRIVER "alsa"
-#elif __APPLE__
-#define DEFAULT_FLUID_DRIVER "coreaudio"
-#else
-#define DEFAULT_FLUID_DRIVER "sndio"
-#endif
-
 typedef struct {
     fixed_t x;
     fixed_t y;

--- a/src/engine/s_sound.c
+++ b/src/engine/s_sound.c
@@ -483,13 +483,10 @@ int S_AdjustSoundParams(fixed_t x, fixed_t y, int* vol, int* sep) {
 // S_RegisterCvars
 //
 
-CVAR_EXTERNAL(s_driver);
-
 void S_RegisterCvars(void) {
     CON_CvarRegister(&s_sfxvol);
     CON_CvarRegister(&s_musvol);
     CON_CvarRegister(&s_gain);
-    CON_CvarRegister(&s_driver);
 }
 
 


### PR DESCRIPTION
This also makes some gcc warnings about redefining DEFAULT_FLUID_DRIVER go away.