### PR TITLE
Audio cleanup

### DIFF
--- a/src/engine/i_audio.h
+++ b/src/engine/i_audio.h
@@ -38,17 +38,13 @@ typedef struct {
 // FMOD Studio
 
 #define MAX_GAME_SFX 256
-#define MAX_FMOD_MUSIC_TRACKS 138
 
 struct Sound {
     FMOD_SYSTEM* fmod_studio_system;
     FMOD_SYSTEM* fmod_studio_system_music;
 
     FMOD_SOUND* fmod_studio_sound[MAX_GAME_SFX];
-    //FMOD_SOUND* fmod_studio_sound_plasma[MAX_GAME_SFX];
-    FMOD_SOUND* fmod_studio_music[MAX_FMOD_MUSIC_TRACKS];
 
-    FMOD_CHANNEL* fmod_studio_channel;
     FMOD_CHANNEL* fmod_studio_channel_music;
     FMOD_CHANNEL* fmod_studio_channel_loop;
     FMOD_CHANNEL* fmod_studio_channel_plasma_loop;


### PR DESCRIPTION
- added `StopChannel()` and `ReleaseSound()` wrapper to related FMOD functions, assigning the argument
pointer  to `NULL` as it must not be used afterwards. This fixes a bunch of `FMOD_ERROR_CHECK` error traces because
of invoking FMOD API on invalid (stopped or released) objects
- removed dead code
- call  `FMOD_ERROR_CHECK()` on all FMOD API calls
- added `FIXME` comments in some places where it seems function is incomplete or unimplemented
- simplified some `if` constructs
