### PR TITLE
fix compilation error

### DIFF
--- a/src/engine/am_map.c
+++ b/src/engine/am_map.c
@@ -98,7 +98,6 @@ CVAR(am_drawobjects, 0);
 CVAR(am_overlay, 0);
 
 extern fixed_t R_Interpolate(fixed_t ticframe, fixed_t updateframe, boolean enable);
-extern float rendertic_frac;
 
 CVAR_EXTERNAL(v_msensitivityx);
 CVAR_EXTERNAL(v_msensitivityy);


### PR DESCRIPTION
```
src/engine/am_map.c:101:14: error: conflicting types for ‘rendertic_frac’; have ‘float’
  101 | extern float rendertic_frac;
      |              ^~~~~~~~~~~~~~
In file included from src/engine/dgl.h:25,
                 from src/engine/doomdef.h:65,
                 from src/engine/am_map.c:28:
src/engine/i_system.h:37:16: note: previous declaration of ‘rendertic_frac’ with type ‘fixed_t’ {aka ‘int’}
   37 | extern fixed_t rendertic_frac;
      |                ^~~~~~~~~~~~~~

```