### PR TITLE
Fix compilation with gcc 15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ FMOD_LIB_DIR=$(FMOD_STUDIO_SDK_ROOT)/api/core/lib/$(ARCH)
 CC ?= gcc
 
 # -DDOOM_UNIX_INSTALL -DDOOM_UNIX_SYSTEM_DATADIR=\"/usr/share/games/doom64ex-plus\"
-CFLAGS += $(shell pkg-config --cflags $(libs)) -I$(FMOD_INC_DIR) -MD
+CFLAGS += $(shell pkg-config --cflags $(libs)) -I$(FMOD_INC_DIR) -MD -Wno-incompatible-pointer-types
 
 # put current directory (.) in the rpath so DOOM64Ex-Plus can also find libfmod.so.xx in the current directory
 LDFLAGS += $(shell pkg-config --libs $(libs)) -lm -L$(FMOD_LIB_DIR) -lfmod -Wl,-rpath=.


### PR DESCRIPTION
gcc 15 defaults to C23 standard, resulting in a bunch of errors below that are silenced with `-Wno-incompatible-pointer-types`.

```
src/engine/info.c:1231:60: error: initialization of ‘void (*)(void *)’ from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
 1231 |         /*S_SPID_RUN7*/                 { SPR_SPID, 3, 4, {A_Chase}, S_SPID_RUN8 },
      |                                                            ^~~~~~~
src/engine/info.c:1231:60: note: (near initialization for ‘states[1005].action.acp1’)
src/engine/info.c:91:6: note: ‘A_Chase’ declared here
   91 | void A_Chase();
```

For the change in behavior in C23, see:

https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters

Alternative could be to change all these callbacks with no argument to `(void *)` but seems a bit tedious and not needed.