### PR TITLE
Fix libpng warnings and reduce doom64ex-plus.wad size by half

### DIFF
--- a/src/engine/i_png.c
+++ b/src/engine/i_png.c
@@ -246,6 +246,11 @@ byte* I_PNGReadData(int lump, bool palette, bool nopack, bool alpha,
         }
     }
 
+    // needed to avoid this warning
+    // libpng warning: Interlace handling should be turned on when using png_read_image
+    // concern lumps: CRSHAIRS, CONFONT, BUTTONS
+    png_set_interlace_handling(png_ptr);
+
     // refresh png information
     png_read_update_info(png_ptr, info_ptr);
 


### PR DESCRIPTION
This fixes these libpng warning:

1.

libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: cHRM chunk does not match sRGB

This one is emitted for lumps USLEGAL (in doom64ex-plus.wad) and SYMBOLS (in DOOM64.WAD). First one is fixed by rewriting an optimized PNG with SLADE. Second one is in the main data WAD and cannot be fixed

2.

libpng warning: Interlace handling should be turned on when using png_read_image

This one is caused by lumps CRSHAIRS, CONFONT, BUTTONS that use interlacing. Calling png_set_interlace_handling prior fixes it

--

Moreover the size of doom64ex-plus.wad is considerably reduced by optimizing with SLADE the TITLE lump PNG