### PR TITLE
fix audio shutdown

### DIFF
--- a/src/engine/sc_main.c
+++ b/src/engine/sc_main.c
@@ -165,11 +165,7 @@ static int SC_SetData(void* data, const scdatatable_t* table) {
 				*(int*)pointer = sc_parser.getint();
 				break;
 			case 'b':
-#ifndef __APPLE__
-				*(int*)pointer = true;
-#else
 				*(boolean*)pointer = true;
-#endif
 				break;
 			case 'c':
 				sc_parser.compare("="); // expect a '='


### PR DESCRIPTION
- properly exit the sequencer thread, removing a "leaked thread" SDL warning on exit
- fix "FMOD Studio" error on exit when stopping `fmod_studio_channel_music`

// And also:

removed that `#ifndef __APPLE__` change introduced a few commits ago for no reason (!!!), reintroducing an unaligned memory access bug that I fixed previously...