### PR TITLE
Fix menu issues

### DIFF
--- a/src/engine/m_menu.c
+++ b/src/engine/m_menu.c
@@ -1380,7 +1380,7 @@ menu_t MouseDef = {
 	MouseDefault,
 	-1,
 	0,
-	0.925f,
+	0.8f,
 	NULL,
 	MouseBars
 };
@@ -1397,7 +1397,7 @@ void M_DrawMouse(void) {
 		msgNames[(int)v_mlookinvert.value]);
 	Draw_BigText(MouseDef.x + 144, MouseDef.y + LINEHEIGHT * mouse_yaxismove, MENUCOLORRED,
 		msgNames[(int)v_yaxismove.value]);
-	Draw_BigText(144, MouseDef.x + LINEHEIGHT * mouse_xaxismove, MENUCOLORRED,
+	Draw_BigText(MouseDef.x + 144, MouseDef.y + LINEHEIGHT * mouse_xaxismove, MENUCOLORRED,
 		msgNames[(int)v_xaxismove.value]);
 
 }
@@ -1604,7 +1604,7 @@ menu_t DisplayDef = {
 	DisplayDefault,
 	-1,
 	0,
-	0.715f,
+	0.6f,
 	DisplayHints,
 	DisplayBars
 };


### PR DESCRIPTION
- HUD menu extending past the screen and overlapping help text
- Mouse menu extending past the screen
- Mouse menu "X Axis move" value not drawn at the correct position

Fixes #333