### PR TITLE
fix compilation error with C23 compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ FMOD_LIB_DIR=$(FMOD_STUDIO_SDK_ROOT)/api/core/lib/$(ARCH)
 CC ?= gcc
 
 # -DDOOM_UNIX_INSTALL -DDOOM_UNIX_SYSTEM_DATADIR=\"/usr/share/games/doom64ex-plus\"
-CFLAGS += $(shell pkg-config --cflags $(libs)) -I$(FMOD_INC_DIR) -MD -Wno-incompatible-pointer-types
+CFLAGS += $(shell pkg-config --cflags $(libs)) -I$(FMOD_INC_DIR) -MD
 
 # put current directory (.) in the rpath so DOOM64Ex-Plus can also find libfmod.so.xx in the current directory
 LDFLAGS += $(shell pkg-config --libs $(libs)) -lm -L$(FMOD_LIB_DIR) -lfmod -Wl,-rpath=.

--- a/src/engine/d_think.h
+++ b/src/engine/d_think.h
@@ -28,13 +28,13 @@
 //  we will need to handle the various
 //  action functions cleanly.
 //
-typedef void(*actionf_v)(void);
+typedef void(*actionf_v)();
 typedef void(*actionf_p1)(void*);
 typedef void(*actionf_p2)(void*, void*);
 
 typedef union {
-	actionf_p1  acp1;
 	actionf_v   acv;
+	actionf_p1  acp1;
 	actionf_p2  acp2;
 } actionf_t;
 

--- a/src/engine/net_server.c
+++ b/src/engine/net_server.c
@@ -827,7 +827,7 @@ static void NET_SV_ParseGameData(net_packet_t* packet, net_client_t* client)
 
 	// Read header
 
-	if (!NET_ReadInt8(packet, (int8_t *)&ackseq)
+	if (!NET_ReadInt8(packet, (int *)&ackseq)
 		|| !NET_ReadInt8(packet, &seq)
 		|| !NET_ReadInt8(packet, &num_tics))
 	{
@@ -946,7 +946,7 @@ static void NET_SV_ParseGameDataACK(net_packet_t* packet, net_client_t* client)
 
 	// Read header
 
-	if (!NET_ReadInt8(packet, (int8_t *)&ackseq))
+	if (!NET_ReadInt8(packet, (int *)&ackseq))
 	{
 		return;
 	}


### PR DESCRIPTION
See https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters

With gcc 15 (which uses C23 by default),  `-Wno-incompatible-pointer-types` had to be used to get rid of these many errors:

```
src/engine/info.c:1231:60: error: initialization of ‘void (*)(void *)’ from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
 1231 |         /*S_SPID_RUN7*/                 { SPR_SPID, 3, 4, {A_Chase}, S_SPID_RUN8 },
      |                                                            ^~~~~~~
src/engine/info.c:1231:60: note: (near initialization for ‘states[1005].action.acp1’)
src/engine/info.c:91:6: note: ‘A_Chase’ declared here
   91 | void A_Chase();
```

This is what 694b4278e58ff771e957817a756de89890d85493 did as an easy work-around.

Instead of using a gcc specific command-line switch, this PR fixes the problem at the root for any C23 compiler. Also tested working with older versions of gcc and clang. But not tested wiht MSVC on Windows (although I do not see why there would be a problem).