### PR TITLE
fix sound possibly not playing after a while

### DIFF
--- a/src/engine/i_audio.c
+++ b/src/engine/i_audio.c
@@ -1197,6 +1197,13 @@ void I_InitSequencer(void) {
     seqready = true;
 }
 
+
+void I_Update(void) {
+    if(sound.fmod_studio_system) {
+        FMOD_ERROR_CHECK(FMOD_System_Update(sound.fmod_studio_system));
+    }
+}
+
 //
 // I_GetMaxChannels
 //
@@ -1381,7 +1388,6 @@ void I_UpdateListenerPosition(fixed_t player_world_x, fixed_t player_world_y_dep
     listener_forward.y = 0.0f;
 
     FMOD_ERROR_CHECK(FMOD_System_Set3DListenerAttributes(sound.fmod_studio_system, 0, &listener_pos, &listener_vel, &listener_forward, &listener_up));
-    FMOD_ERROR_CHECK(FMOD_System_Update(sound.fmod_studio_system));
 }
 
 // FMOD Studio SFX API
@@ -1421,7 +1427,7 @@ int FMOD_StartSound(int sfx_id, sndsrc_t* origin, int volume, int pan) {
         final_volume = 1.0f;
     }
     FMOD_ERROR_CHECK(FMOD_Channel_SetVolume(sfx_channel, final_volume));
-    
+
     if (origin) {
         mobj_t* mobj = (mobj_t*)origin;
         FMOD_VECTOR pos, vel;

--- a/src/engine/i_audio.h
+++ b/src/engine/i_audio.h
@@ -88,6 +88,7 @@ void FMOD_ResumeSFXLoop(void);
 
 void I_InitSequencer(void);
 void I_ShutdownSound(void);
+void I_Update(void);
 void I_UpdateChannel(int c, int volume, int pan, fixed_t x, fixed_t y);
 void I_RemoveSoundSource(int c);
 void I_SetMusicVolume(float volume);

--- a/src/engine/s_sound.c
+++ b/src/engine/s_sound.c
@@ -333,6 +333,8 @@ void S_UpdateSounds(void) {
             I_UpdateChannel(i, volume, sep, source->x, source->y);
         }
     }
+
+    I_Update();
 }
 
 //


### PR DESCRIPTION
Call `FMOD_System_Update` each frame as [per doc](https://fmod.com/docs/2.03/api/core-api-system.html#system_update), so channels created in `FMOD_StartSound` are properly recycled instead of silently failing to play after 64 channels have been created.

Previously `FMOD_System_Update` was called by `I_UpdateListenerPosition`, but not necessarily each frame (especially not at all on menus).

This fixes at least #350 and possibly other occurrences of sound mysteriously failing to play if 64 sounds have been played and `FMOD_System_Update` had not been called in-between..

