### PR TITLE
Misc fixes and changes

### DIFF
--- a/src/engine/am_map.c
+++ b/src/engine/am_map.c
@@ -1059,8 +1059,8 @@ void AM_Drawer(void) {
 		}
 	}
 	else {
-		base_x = automapx + automappanx;
-		base_y = automapy + automappany;
+		base_x = automapx;
+		base_y = automapy;
 		base_angle = automapangle;
 	}
 	render_x = base_x;

--- a/src/engine/g_actions.c
+++ b/src/engine/g_actions.c
@@ -1235,13 +1235,9 @@ void G_GetActionBindings(char* buff, char* action) {
 			if (p != buff) {
 				*(p++) = ',';
 			}
-
-			if (i < MOUSE_BUTTONS - 2) {
-				dstrcpy(p, "mouse?");
-				p[5] = i + '1';
-				p += 6;
-			}
-
+			dstrcpy(p, "mouse?");
+			p[5] = i + '1';
+			p += 6;
 			if (p - buff >= MAX_MENUACTION_LENGTH) {
 				return;
 			}
@@ -1280,10 +1276,8 @@ void G_UnbindAction(char* action) {
 		if (IsSameAction(action, MouseActions[i])) {
 			char p[16];
 
-			if (i < MOUSE_BUTTONS - 2) {
-				dstrcpy(p, "mouse?");
-				p[5] = i + '1';
-			}
+			dstrcpy(p, "mouse?");
+			p[5] = i + '1';
 
 			Unbind(p);
 			return;

--- a/src/engine/i_audio.c
+++ b/src/engine/i_audio.c
@@ -1262,6 +1262,14 @@ void I_UpdateChannel(int c, int volume, int pan, fixed_t x, fixed_t y) {
     chan->pan = (byte)(pan >> 1);
 }
 
+void ShutdownSystem(FMOD_SYSTEM **system) {
+    if(*system) {
+        FMOD_ERROR_CHECK(FMOD_System_Close(*system));
+        FMOD_ERROR_CHECK(FMOD_System_Release(*system));
+        *system = NULL;
+    }
+}
+
 //
 // I_ShutdownSound
 // Shutdown sound when player exits the game / error occurs
@@ -1282,11 +1290,8 @@ void I_ShutdownSound(void)
     // must be done after stopping fmod_studio_channel_music
     ReleaseSound(&currentMidiSound);
 
-    FMOD_ERROR_CHECK(FMOD_System_Close(sound.fmod_studio_system));
-    FMOD_ERROR_CHECK(FMOD_System_Release(sound.fmod_studio_system));
-
-    FMOD_ERROR_CHECK(FMOD_System_Close(sound.fmod_studio_system_music));
-    FMOD_ERROR_CHECK(FMOD_System_Release(sound.fmod_studio_system_music));
+    ShutdownSystem(&sound.fmod_studio_system);
+    ShutdownSystem(&sound.fmod_studio_system_music);
 }
 
 //

--- a/src/engine/i_sdlinput.c
+++ b/src/engine/i_sdlinput.c
@@ -486,9 +486,11 @@ static int I_TranslateKey(const int key)
 
 static int I_SDLtoDoomMouseState(Uint8 buttonstate) {
 	return 0
-		| (buttonstate & SDL_BUTTON_MASK(SDL_BUTTON_LEFT) ? 1 : 0)
-		| (buttonstate & SDL_BUTTON_MASK(SDL_BUTTON_MIDDLE) ? 2 : 0)
-		| (buttonstate & SDL_BUTTON_MASK(SDL_BUTTON_RIGHT) ? 4 : 0);
+		| (buttonstate & SDL_BUTTON_LMASK ? 1 : 0)
+		| (buttonstate & SDL_BUTTON_MMASK ? 2 : 0)
+		| (buttonstate & SDL_BUTTON_RMASK ? 4 : 0)
+		| (buttonstate & SDL_BUTTON_X1MASK ? 8 : 0)
+		| (buttonstate & SDL_BUTTON_X2MASK ? 16 : 0);
 }
 
 //

--- a/src/engine/m_menu.c
+++ b/src/engine/m_menu.c
@@ -2690,6 +2690,7 @@ void M_BuildControlMenu(void) {
 			menu->menuitems[item].routine = M_ChangeKeyBinding;
 
 			G_GetActionBindings(&menu->menuitems[item].name[17], PlayerActions[item].action);
+
 		}
 		else {
 			menu->menuitems[item].status = -1;
@@ -3911,10 +3912,6 @@ boolean M_Responder(event_t* ev) {
 		}
 	}
 
-	if (ch == -1) {
-		return false;
-	}
-
 	if (MenuBindActive == true) { //key Bindings
 		if (ch == KEY_ESCAPE) {
 			MenuBindActive = false;
@@ -3925,6 +3922,10 @@ boolean M_Responder(event_t* ev) {
 			M_BuildControlMenu();
 		}
 		return true;
+	}
+
+	if (ch == -1) {
+		return false;
 	}
 
 	// save game / player name string input


### PR DESCRIPTION
3 changes:

- add support for binding MOUSE2 (middle click), MOUSE4 and MOUSE5 buttons

- Fix pressing panning keys that would move map in diagonals instead of left/right/bottom/up directions

- fix crash on game exit if game started with -nosound and/or -nomusic