### PR TITLE
do not post keyboard events for unhandled keys

### DIFF
--- a/src/engine/i_sdlinput.c
+++ b/src/engine/i_sdlinput.c
@@ -594,13 +594,17 @@ void I_GetEvent(SDL_Event* Event) {
 			break;
 		event.type = ev_keydown;
 		event.data1 = I_TranslateKey(Event->key.key);
-		D_PostEvent(&event);
+		if(event.data1) {
+			D_PostEvent(&event);
+		}
 		break;
 
 	case SDL_EVENT_KEY_UP:
 		event.type = ev_keyup;
 		event.data1 = I_TranslateKey(Event->key.key);
-		D_PostEvent(&event);
+		if(event.data1) {
+			D_PostEvent(&event);
+		}
 		break;
 
 	case SDL_EVENT_MOUSE_BUTTON_DOWN:


### PR DESCRIPTION
This fixes (at least) the menu binding screen going to next item when an unhandled key is pressed (eg Windows key), a consequence of the I_TranslateKey refactor (that now returns 0 for unhandled key when it previously always returned non-zero)