### PR TITLE
Partial fix for #376

### DIFF
--- a/src/engine/w_wad.c
+++ b/src/engine/w_wad.c
@@ -348,9 +348,11 @@ void W_Init(void) {
 			}
 		}
 	}
+
+	W_HashLumps();
+		
 	I_Printf("W_KPFInit: Init KPFfiles.\n");
 	W_KPFInit();
-	W_HashLumps();
 }
 
 static boolean nonmaplump = false;


### PR DESCRIPTION
This fixes TITLE and USLEGAL lumps not being replaced by `W_AddMemoryLump` because not being hashed.
However, CURSOR lump is still problematic because it it is not an existing lump (thus get added as a new lump) and the code in 
`GL_BindGfxTexture()` assumes an existing lump as parameter between `SYMBOLS` and `MOUNTC`, not one that was added by `W_AddMemoryLump`.
