### PR TITLE
resize TITLE and USLEGAL graphics to window size

### DIFF
--- a/src/engine/i_png.c
+++ b/src/engine/i_png.c
@@ -40,11 +40,15 @@
 
 #define STB_IMAGE_IMPLEMENTATION
 #define STB_IMAGE_RESIZE2_IMPLEMENTATION
+#define STB_IMAGE_WRITE_IMPLEMENTATION
 
+#define STBI_ONLY_PNG
+#define STBI_NO_STDIO
+
+#define STBI_WRITE_NO_STDIO
 #define STBIW_PNG_COMPRESSION_LEVEL 1
 #define STBIW_PNG_FILTER 0
 
-#define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image.h"
 #include "stb_image_resize2.h"
 #include "stb_image_write.h"

--- a/src/engine/w_wad.c
+++ b/src/engine/w_wad.c
@@ -54,6 +54,8 @@ typedef struct memlump_s {
 static memlump_t g_memlumps[MAX_MEMLUMPS];
 static int g_nmemlumps = 0;
 
+extern int win_px_w, win_px_h;
+
 #pragma pack(push, 1)
 
 //
@@ -614,23 +616,23 @@ void W_KPFInit(void)
 	};
 
 	// atsb: let's be strict, if these aren't present, then we bail out at 30,000ft without a parachute!
-	static const struct override_item items[] = {
-		{ "TITLE",   { "gfx/Doom64_HiRes.png", NULL }, 1920, 1080 },
-		{ "USLEGAL", { "gfx/legals.png",       NULL }, 1920, 1080 },
+	const struct override_item items[] = {
+		{ "TITLE",   { "gfx/Doom64_HiRes.png", NULL }, win_px_w, win_px_h },
+		{ "USLEGAL", { "gfx/legals.png",       NULL }, win_px_w, win_px_h },
 		{ "CURSOR",  { "gfx/cursor.png",       NULL }, 33, 32 },
 	};
 
-	int need = (int)(sizeof(items) / sizeof(items[0]));
+	int need = SDL_arraysize(items);
 	int loaded = 0;
 
 	char missing[256];
 	missing[0] = 0;
 
-	for (size_t it = 0; it < sizeof(items) / sizeof(items[0]); ++it) {
+	for (size_t it = 0; it < need; ++it) {
 		const struct override_item* ov = &items[it];
 		int this_ok = 0;
 
-		for (int k = 0; k < (int)(sizeof(kpf_candidates) / sizeof(kpf_candidates[0])) && !this_ok; ++k) {
+		for (int k = 0; k < SDL_arraysize(kpf_candidates) && !this_ok; ++k) {
 			const char* kpf = kpf_candidates[k];
 
 			for (size_t p = 0; ov->paths[p] != NULL && !this_ok; ++p) {


### PR DESCRIPTION
- decreased compilation times of `i_png.c` a tiny bit pruning some of the `stb_` unused stuff
- use `SDL_arraysize` macro