### PR TITLE
I_FindDataFile cache returned values

### DIFF
--- a/src/engine/i_audio.c
+++ b/src/engine/i_audio.c
@@ -1081,8 +1081,10 @@ static int Seq_RegisterSounds(void) {
         FMOD_SOUND* snd = NULL;
 
         if (is_pcm) {
-            // exclude NOSOUND WAV lump as it cannot be created
-            if (!(hinted == FMOD_SOUND_TYPE_WAV && len <= 44)) {
+            if (hinted == FMOD_SOUND_TYPE_WAV && len <= 44) {
+                // exclude NOSOUND WAV lump as it cannot be created
+                result = FMOD_ERR_UNSUPPORTED;
+            } else {
                 result = FMOD_System_CreateSound(
                     sound.fmod_studio_system,
                     (const char*)p,
@@ -1739,7 +1741,6 @@ int FMOD_StartMusic(int mus_id) {
             &currentMidiSound
         );
         FMOD_ERROR_CHECK(result);
-        if (exinfo.dlsname) free((void*)exinfo.dlsname);
 
         if (result == FMOD_OK && currentMidiSound) {
             result = FMOD_System_PlaySound(sound.fmod_studio_system_music, currentMidiSound, 
@@ -1780,7 +1781,6 @@ int FMOD_StartMusic(int mus_id) {
             exinfo.dlsname = I_FindDataFile("DOOMSND.DLS");
             result = FMOD_System_CreateSound(sound.fmod_studio_system_music, (const char*)p, FMOD_OPENMEMORY | FMOD_LOOP_NORMAL | FMOD_2D, &exinfo, &currentMidiSound);
             FMOD_ERROR_CHECK(result);
-            if (exinfo.dlsname) free((void*)exinfo.dlsname);
             if (result == FMOD_OK && currentMidiSound) {
                 result = FMOD_System_PlaySound(sound.fmod_studio_system_music, currentMidiSound, sound.master_music, false, &sound.fmod_studio_channel_music);
                 FMOD_ERROR_CHECK(result);
@@ -1815,7 +1815,6 @@ int FMOD_StartMusic(int mus_id) {
                 exinfo.dlsname = I_FindDataFile("DOOMSND.DLS");
                 result = FMOD_System_CreateSound(sound.fmod_studio_system_music, (const char*)midip, FMOD_OPENMEMORY | FMOD_LOOP_NORMAL | FMOD_2D, &exinfo, &currentMidiSound);
                 FMOD_ERROR_CHECK(result);
-                if (exinfo.dlsname) free((void*)exinfo.dlsname);
                 if (result == FMOD_OK && currentMidiSound) {
                     result = FMOD_System_PlaySound(sound.fmod_studio_system_music, currentMidiSound, sound.master_music, false, &sound.fmod_studio_channel_music);
                     FMOD_ERROR_CHECK(result);

--- a/src/engine/i_system.h
+++ b/src/engine/i_system.h
@@ -75,6 +75,9 @@ extern boolean    DigiJoy;
 #ifdef SDL_PLATFORM_WIN32
 #include <windows.h>
 boolean I_GetRegistryString (HKEY root, const wchar_t *dir, const wchar_t *keyname, char *out, size_t maxchars);
+
+#define strdup _strdup
+
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__)

--- a/src/engine/kpf.c
+++ b/src/engine/kpf.c
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
 #include <limits.h>
 #include <zlib.h>
 

--- a/src/engine/kpf.h
+++ b/src/engine/kpf.h
@@ -1,5 +1,3 @@
-#include <stddef.h>
-
 #define ZIP_SIG_EOCD   0x06054b50u
 #define ZIP_SIG_CDH    0x02014b50u
 #define ZIP_SIG_LFH    0x04034b50u

--- a/src/engine/m_misc.c
+++ b/src/engine/m_misc.c
@@ -74,7 +74,7 @@ char* M_StringDuplicate(const char* orig)
 {
 	char* result;
 
-	result = SDL_strdup(orig);
+	result = strdup(orig);
 
 	if (result == NULL)
 	{

--- a/src/engine/net_server.c
+++ b/src/engine/net_server.c
@@ -418,7 +418,7 @@ static void NET_SV_InitNewClient(net_client_t* client,
 	NET_Conn_InitServer(&client->connection, addr);
 	client->addr = addr;
 	client->last_send_time = -1;
-	client->name = SDL_strdup(player_name);
+	client->name = M_StringDuplicate(player_name);
 
 	// init the ticcmd send queue
 

--- a/src/engine/p_mapinfo.c
+++ b/src/engine/p_mapinfo.c
@@ -19,31 +19,15 @@
 //
 //-----------------------------------------------------------------------------
 
-#include <math.h>
 #include <stdlib.h>
+#include <SDL3/SDL_stdinc.h>
 
-#include "p_setup.h"
 #include "doomdef.h"
-#include "i_swap.h"
-#include "m_fixed.h"
-#include "g_game.h"
 #include "i_system.h"
 #include "w_wad.h"
-#include "p_local.h"
 #include "doomstat.h"
-#include "t_bsp.h"
-#include "p_macros.h"
-#include "info.h"
-#include "m_misc.h"
-#include "tables.h"
-#include "gl_texture.h"
-#include "r_sky.h"
-#include "r_main.h"
-#include "r_lights.h"
-#include "r_things.h"
 #include "con_console.h"
 #include "con_cvar.h"
-#include "m_random.h"
 #include "z_zone.h"
 #include "sc_main.h"
 #include "kpf.h"

--- a/src/engine/w_wad.c
+++ b/src/engine/w_wad.c
@@ -271,7 +271,6 @@ void W_Init(void) {
 	}
 
 	wadfile = W_OpenFile(iwad);
-    free(iwad);
     
 	W_Read(wadfile, 0, &header, sizeof(header));
 
@@ -321,7 +320,6 @@ void W_Init(void) {
 
 	if ((doom64expluswad = I_FindDataFile("doom64ex-plus.wad"))) {
 		W_MergeFile(doom64expluswad);
-		free(doom64expluswad);
 	}
 	else {
 		I_Error("W_Init: doom64ex-plus.wad not found");
@@ -644,7 +642,6 @@ void W_KPFInit(void)
 				char* path = I_FindDataFile((char *)kpf);
 				if(!path) continue;
 				int ret = KPF_ExtractFileCapped(path, inner, &data, &size, KPF_PNG_CAP_BYTES);
-			    free(path);
 				if(!ret) continue;
 
 				if (ov->max_w > 0 && ov->max_h > 0) {


### PR DESCRIPTION
- `I_FindDataFile()` now cache returned values. The caching reduces log spam (each accessed file only logged once) and does not require the caller to free the returned path
- changed `M_StringDuplicate()` to use regular `strdup` instead of `SDL_strdup()` as the latter required to use `SDL_free()` instead of `free()`
- minor include cleanup