### PR TITLE
Remove "Windowed" menu entry and cleanup

### DIFF
--- a/src/engine/am_map.c
+++ b/src/engine/am_map.c
@@ -108,6 +108,7 @@ static CMD(Automap) {
 	}
 
 	if (!automapactive) {
+		if (menuactive) return;
 		AM_Start();
 	}
 	else {

--- a/src/engine/d_main.c
+++ b/src/engine/d_main.c
@@ -68,8 +68,6 @@ static int      screenalphatext;
 static int      creditstage;
 static int      creditscreenstage;
 
-int        InWindow;
-int        InWindowBorderless;
 boolean        setWindow = true;
 int             validcount = 1;
 boolean        windowpause = false;

--- a/src/engine/doomstat.h
+++ b/src/engine/doomstat.h
@@ -90,8 +90,6 @@ extern  boolean    mainmenuactive;
 extern  boolean    allowclearmenu;
 extern  boolean    paused;             // Game Pause?
 
-extern  int    InWindow;
-extern  int    InWindowBorderless;
 extern  boolean    setWindow;
 extern  int         ViewHeight;
 extern  int         ViewWidth;

--- a/src/engine/i_video.c
+++ b/src/engine/i_video.c
@@ -36,8 +36,6 @@ SDL_GLContext   glContext = NULL;
 
 CVAR(r_trishader, 1);
 CVAR(v_checkratio, 0);
-CVAR(v_windowed, 1);
-CVAR(v_windowborderless, 0);
 
 CVAR_CMD(v_vsync, 1) {
     SDL_GL_SetSwapInterval((int)v_vsync.value);
@@ -123,9 +121,6 @@ void I_InitScreen(void) {
     unsigned int  flags = 0;
     char          title[256];
 
-    InWindow = (int)v_windowed.value;
-    InWindowBorderless = (int)v_windowborderless.value;
-
     int native_w = 0, native_h = 0;
     GetNativeDisplayPixels(&native_w, &native_h, window);
 
@@ -151,17 +146,18 @@ void I_InitScreen(void) {
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
-    flags |= SDL_WINDOW_OPENGL | SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_MOUSE_FOCUS | SDL_WINDOW_HIDDEN;
+    flags |= SDL_WINDOW_OPENGL | SDL_WINDOW_MAXIMIZED | SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_MOUSE_FOCUS | SDL_WINDOW_HIDDEN ;
+	
 #ifndef SDL_PLATFORM_MACOS
     flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
 #endif
 
-    if (!InWindow) {
-        flags |= SDL_WINDOW_BORDERLESS;
-    }
-    else if (InWindowBorderless) {
-        flags |= SDL_WINDOW_BORDERLESS;
-    }
+#ifdef SDL_PLATFORM_WINDOWS
+	flags |= SDL_WINDOW_BORDERLESS;
+#else
+    // fullscreen borderless is glitchy on Linux, at least on with i3wm
+    flags |= SDL_WINDOW_FULLSCREEN;
+#endif
 
     if (glContext) { SDL_GL_DestroyContext(glContext); glContext = NULL; }
     if (window) { SDL_DestroyWindow(window); window = NULL; }
@@ -259,7 +255,5 @@ void I_InitVideo(void) {
 void V_RegisterCvars(void) {
     CON_CvarRegister(&r_trishader);
     CON_CvarRegister(&v_checkratio);
-    CON_CvarRegister(&v_windowed);
-    CON_CvarRegister(&v_windowborderless);
     CON_CvarRegister(&v_vsync);
 }

--- a/src/engine/m_menu.c
+++ b/src/engine/m_menu.c
@@ -1735,7 +1735,6 @@ void M_ChangeBrightness(int choice);
 void M_ChangeGammaLevel(int choice);
 void M_ChangeFilter(int choice);
 void M_ChangehudFilter(int choice);
-void M_ChangeWindowed(int choice);
 void M_ChangeAnisotropic(int choice);
 void M_ChangeInterpolateFrames(int choice);
 void M_ChangeAccessibility(int choice);
@@ -1744,7 +1743,6 @@ void M_DrawVideo(void);
 void M_ChangeVsync(int choice);
 
 CVAR_EXTERNAL(v_checkratio);
-CVAR_EXTERNAL(v_windowed);
 CVAR_EXTERNAL(i_brightness);
 CVAR_EXTERNAL(i_gamma);
 CVAR_EXTERNAL(i_brightness);
@@ -1764,7 +1762,6 @@ enum {
 	filter,
 	hud_filter,
 	anisotropic,
-	windowed,
 	interpolate_frames,
 	vsync,
 	accessibility,
@@ -1783,7 +1780,6 @@ menuitem_t VideoMenu[] = {
 	{2,"Filter:",M_ChangeFilter, 'f'},
 	{2,"HUD Filter:",M_ChangehudFilter, 't'},
 	{2,"Anisotropy:",M_ChangeAnisotropic, 'a'},
-	{2,"Windowed:",M_ChangeWindowed, 'w'},
 	{2,"Interpolation:",M_ChangeInterpolateFrames, 'i'},
 	{2,"VSync:",M_ChangeVsync, 'v'},
 	{2,"Accessibility:",M_ChangeAccessibility, 'y'},
@@ -1801,7 +1797,6 @@ char* VideoHints[video_end] = {
 	"toggle texture filtering",
 	"toggle texture filtering on hud and text",
 	"toggle blur reduction on textures",
-	"toggle windowed mode",
 	"toggle frame interpolation to\n achieve smooth framerates",
 	"toggle vsync on or off to prevent screen tearing",
 	"toggle accessibility to\n remove flashing lights",
@@ -1815,7 +1810,6 @@ menudefault_t VideoDefault[] = {
 	{ &r_filter, 0 },
 	{ &r_hudFilter, 0 },
 	{ &r_anisotropic, 1 },
-	{ &v_windowed, 0 },
 	{ &i_interpolateframes, 1 },
 	{ &v_vsync, 1 },
 	{ &v_accessibility, 0 },
@@ -1906,7 +1900,6 @@ void M_DrawVideo(void) {
 	DRAWVIDEOITEM2(filter, r_filter.value, filterType);
 	DRAWVIDEOITEM2(hud_filter, r_hudFilter.value, filterType);
 	DRAWVIDEOITEM2(anisotropic, r_anisotropic.value, msgNames);
-	DRAWVIDEOITEM2(windowed, v_windowed.value, msgNames);
 	DRAWVIDEOITEM2(interpolate_frames, i_interpolateframes.value, onofftype);
 	DRAWVIDEOITEM2(vsync, v_vsync.value, onofftype);
 	DRAWVIDEOITEM2(accessibility, v_accessibility.value, onofftype);
@@ -1993,10 +1986,6 @@ void M_ChangehudFilter(int choice) {
 
 void M_ChangeAnisotropic(int choice) {
 	M_SetOptionValue(choice, 0, 1, 1, &r_anisotropic);
-}
-
-void M_ChangeWindowed(int choice) {
-	M_SetOptionValue(choice, 0, 1, 1, &v_windowed);
 }
 
 void M_ChangeInterpolateFrames(int choice)


### PR DESCRIPTION
- since we are always fullscreen, removed unneeded "Windowed" menu entry and related cvars
- always create window with `SDL_WINDOW_BORDERLESS` on Windows. Use `SDL_WINDOW_FULLSCREEN` on other platforms as at least on Linux the window is not created fullscreen on i3 Window Manager
- disable showing automap while the menu is displayed as it sometimes displays glitchy

Leaving this opened for review to make sure we really want to remove the "Windowed" menu entry.

Also do we really need to grab keyboard with `SDL_SetWindowKeyboardGrab` ? When the keyboard is grabbed , it prevents ALT+TAB to work (only in `SDL_WINDOW_BORDERLESS` mode, it works with `SDL_WINDOW_FULLSCREEN`). Currently only while actively in a level, as keyboard grab is disabled in menus, which allows for ALT+TAB to work if you go to the menu first, which I found confusing when I discovered it as I thought ALT+TAB was not working at all.
SDL doc for `SDL_SetWindowKeyboardGrab`  discourages to use it.

