### PR TITLE
Cache kpf resized PNG to file to decrease startup time

### DIFF
--- a/src/engine/i_system.c
+++ b/src/engine/i_system.c
@@ -374,7 +374,13 @@ char* I_FindDataFile(char* file) {
 boolean I_FileExists(const char* path)
 {
 	struct stat st;
-	return !stat(path, &st) && S_ISREG(st.st_mode);
+	return path && !stat(path, &st) && S_ISREG(st.st_mode);
+}
+
+boolean I_DirExists(const char* path)
+{
+	struct stat st;
+	return path && !stat(path, &st) && S_ISDIR(st.st_mode);
 }
 
 //

--- a/src/engine/i_system.h
+++ b/src/engine/i_system.h
@@ -66,6 +66,7 @@ char* I_GetUserFile(char* file);
 char* I_FindDataFile(char* file);
 
 boolean I_FileExists(const char* path);
+boolean I_DirExists(const char* path);
 
 void I_RegisterCvars(void);
 

--- a/src/engine/i_system_io.h
+++ b/src/engine/i_system_io.h
@@ -22,8 +22,14 @@
 
 // Gibbon - hack from curl to deal with some crap
 // fixes S_ISREG not available with MSVC
-#if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
+#if defined(S_IFMT)
+#if !defined(S_ISREG) && defined(S_IFREG)
 #define S_ISREG(m) (((m)&S_IFMT) == S_IFREG)
+#endif
+#if !defined(S_ISDIR) && defined(S_IFDIR)
+#define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
+#endif
+
 #endif
 
 typedef char filepath_t[MAX_PATH];

--- a/src/engine/m_misc.h
+++ b/src/engine/m_misc.h
@@ -57,9 +57,12 @@ M_AddToBox
 	fixed_t    x,
 	fixed_t    y);
 
+boolean M_CreateDir(char* dirname);
 boolean M_WriteFile(char const* name, void* source, int length);
+int M_ReadFileEx(char const* name, byte** buffer, boolean use_malloc);
 int M_ReadFile(char const* name, byte** buffer);
 int M_FileExists(char* filename);
+long M_FileLengthFromPath(char const* filepath);
 long M_FileLength(FILE* handle);
 boolean M_WriteTextFile(char const* name, char* source, int length);
 void M_ScreenShot(void);


### PR DESCRIPTION
- on first game start, resized PNG in KPF are cached to file in a "kpf_cache" sub-folder of the user dir
- it make subsequent launches of the game much faster as `W_KPFInit()` is almost instant (70ms cached vs 5000ms uncached observed on 6 core CPU from 2018, with TITLE pic resized to 4K)
- cache is error resistant and will fallback to KPF loading if cannot be loaded from cache
- duration that the `W_KPFInit()` function takes to run is displayed in the console
