### PR TITLE
Load kpf localization in the same kpf than PNG

### DIFF
--- a/src/engine/doomdef.h
+++ b/src/engine/doomdef.h
@@ -29,6 +29,7 @@ void*		dmemset(void* s, int c, unsigned int n);
 char*		dstrcpy(char* dest, const char* src);
 void        dstrncpy(char* dest, const char* src, int maxcount);
 int         dstrcmp(const char* s1, const char* s2);
+boolean     dstreq(const char* s1, const char* s2);
 int         dstrncmp(const char* s1, const char* s2, int len);
 int         dstricmp(const char* s1, const char* s2);
 int         dstrnicmp(const char* s1, const char* s2, int len);

--- a/src/engine/i_main.c
+++ b/src/engine/i_main.c
@@ -103,6 +103,15 @@ int dstrcmp(const char* s1, const char* s2) {
 }
 
 //
+// dstreq
+//
+
+boolean dstreq(const char* s1, const char* s2) {
+	return dstrcmp(s1, s2) == 0;
+}
+
+
+//
 // dstrncmp
 //
 

--- a/src/engine/i_system_io.h
+++ b/src/engine/i_system_io.h
@@ -3,7 +3,7 @@
 
 #include <SDL3/SDL_platform_defines.h>
 
-#ifdef SDL_PLATFORM_WINDOWS
+#ifdef SDL_PLATFORM_WIN32
 #include <windows.h> // for MAX_PATH
 #include <io.h>
 #define F_OK 0

--- a/src/engine/i_video.c
+++ b/src/engine/i_video.c
@@ -152,7 +152,7 @@ void I_InitScreen(void) {
     flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
 #endif
 
-#ifdef SDL_PLATFORM_WINDOWS
+#ifdef SDL_PLATFORM_WIN32
 	flags |= SDL_WINDOW_BORDERLESS;
 #else
     // fullscreen borderless is glitchy on Linux, at least on with i3wm

--- a/src/engine/p_mapinfo.c
+++ b/src/engine/p_mapinfo.c
@@ -222,29 +222,29 @@ static const char* LOC_LangPath(int lang) {
     }
 }
 
-static const char* kpf_file_array[] = {
-    "Doom64.kpf", "doom64.kpf", "DOOM64.kpf", NULL
-};
-
 static void LOC_Load(void) {
     CON_CvarRegister(&p_language);
 
     const char* want_inner = LOC_LangPath(p_language.value);
     unsigned char* data = NULL; int size = 0;
 
-    for (int i = 0; kpf_file_array[i]; ++i) {
-        if (KPF_ExtractFile(kpf_file_array[i], want_inner, &data, &size)) {
+    for (int i = 0; i < g_num_kpf; ++i) {
+
+        char* kpf_path = I_FindDataFile(g_kpf_files[i]);
+        if (!kpf_path) continue;
+
+        if (KPF_ExtractFile(kpf_path, want_inner, &data, &size)) {
             LOC_LoadFromBuffer(data, size);
             free(data);
             I_Printf("Localization: Loaded %d entries from %s in %s\n",
-                localisation_count, want_inner, kpf_file_array[i]);
+                localisation_count, want_inner, kpf_path);
             return;
         }
         if (p_language.value != 0) {
             const char* eng = LOC_LangPath(0);
-            if (KPF_ExtractFile(kpf_file_array[i], eng, &data, &size)) {
+            if (KPF_ExtractFile(kpf_path, eng, &data, &size)) {
                 I_Printf("Localization: '%s' not found; fell back to English in %s\n",
-                    want_inner, kpf_file_array[i]);
+                    want_inner, kpf_path);
                 LOC_LoadFromBuffer(data, size);
                 free(data);
                 I_Printf("Localization: loaded %d entries from %s\n",

--- a/src/engine/w_wad.h
+++ b/src/engine/w_wad.h
@@ -37,6 +37,11 @@ typedef struct {
 extern lumpinfo_t* lumpinfo;
 extern int numlumps;
 
+// "8 kpf ought to be enough for anybody"
+#define MAX_KPF_FILES 8
+extern char* g_kpf_files[MAX_KPF_FILES];
+extern int g_num_kpf;
+
 void            W_Init(void);
 wad_file_t* W_AddFile(char* filename);
 unsigned int    W_HashLumpName(const char* str);


### PR DESCRIPTION
- this also fixes Doom64.kpf for localization only searched in the current directory instead of all data files dirs (`I_FindDataFile`).
- added helper function `dstreq()` more descriptive than `!dstrcmp(...)`
- a few other minor changes