### PR TITLE
Use SDL_GetPrefsPath() for user data files on all platforms and more

### DIFF
--- a/src/engine/doomdef.h
+++ b/src/engine/doomdef.h
@@ -39,6 +39,7 @@ int         dstrlen(const char* string);
 char*		dstrrchr(char* s, char c);
 void        dstrcat(char* dest, const char* src);
 char*		dstrstr(char* s1, char* s2);
+boolean		dstrisempty(char* s);
 int         datoi(const char* str);
 float       datof(char* str);
 int         dhtoi(char* str);

--- a/src/engine/g_settings.c
+++ b/src/engine/g_settings.c
@@ -21,30 +21,74 @@
 
 #include <stdlib.h>
 
+#include <SDL3/SDL_storage.h>
+
 #include "g_settings.h"
 #include "z_zone.h"
 #include "m_misc.h"
 #include "i_system.h"
 #include "g_actions.h"
 
-static char* ConfigFileName =
-#ifdef SDL_PLATFORM_WIN32
-"config.cfg"
-#else
-NULL
-#endif
-;
-
-char    DefaultConfig[] = 
+char    DefaultConfig[] =
 #include "defconfig.inc"    
 ;
+
+
 
 //
 // G_ExecuteMultipleCommands
 //
 
+#include "i_system_io.h"
+
+
+// move any existing data file present in SDL_GetBasePath() to I_GetUserDir()
+// that's necessary to migrate files from existing install prior or equal to v4.2.0.0 
+// to the new location, especially on Windows where data files where stored in the install directory (SDL_GetBasePath())
+static void MoveUserDataFiles() {
+	char* src_dirpath = (char *)SDL_GetBasePath();
+	if (!src_dirpath) return;
+
+	SDL_Storage* src_storage = SDL_OpenFileStorage(src_dirpath);
+	if (!src_storage) return;
+
+	char* patterns[] = {
+		"config.cfg",
+		"sshot???.png",
+		"doomsav*.dsg"
+	};
+
+	for (int i = 0; i < SDL_arraysize(patterns); i++) {
+		int count = 0;
+		char** matches = SDL_GlobStorageDirectory(src_storage, NULL, patterns[i], 0, &count);
+		
+		if (matches) {
+			for (int i = 0; i < count; i++) {
+				char* filename = matches[i];
+				if (!M_MoveFile(filename, src_dirpath, I_GetUserDir())) {
+					I_Printf("WARNING: failed to move %s to %s\n", filename, I_GetUserDir());
+				}
+			}
+			SDL_free(matches);
+		}
+	}
+		
+	SDL_CloseStorage(src_storage);
+}
+
+// return fully qualified non-NULL config file name. Must NOT be freed by caller
 char* G_GetConfigFileName(void) {
-	return I_GetUserFile("config.cfg");
+	static char* g_config_filename = NULL;
+
+	if (!g_config_filename) {
+
+		MoveUserDataFiles();
+
+		g_config_filename = I_GetUserFile("config.cfg");
+		I_Printf("Config file: %s\n", g_config_filename);
+	}
+
+	return g_config_filename;
 }
 
 void G_ExecuteMultipleCommands(char* data) {
@@ -117,15 +161,5 @@ void G_ExecuteFile(char* name) {
 //
 
 void G_LoadSettings(void) {
-	int        p;
-
-	p = M_CheckParm("-config");
-	if (p && (p < myargc - 1)) {
-		if (myargv[p + 1][0] != '-') {
-			ConfigFileName = myargv[p + 1];
-		}
-	}
-    char *filename = G_GetConfigFileName();
-	G_ExecuteFile(filename);
-    free(filename);
+	G_ExecuteFile(G_GetConfigFileName());
 }

--- a/src/engine/i_main.c
+++ b/src/engine/i_main.c
@@ -211,6 +211,14 @@ char* dstrrchr(char* s, char c) {
 }
 
 //
+// dstrisempty
+//
+
+boolean dstrisempty(char *s) {
+	return !s || s[0] == '\0';
+}
+
+//
 // dstrcat
 //
 

--- a/src/engine/m_misc.h
+++ b/src/engine/m_misc.h
@@ -19,19 +19,10 @@
 #define __M_MISC__
 
 #include <stdio.h>
-#include <stdarg.h>
 #include <stdbool.h>
 
 #include "doomtype.h"
 #include "m_fixed.h"
-
-//
-// MISC
-//
-
-#ifndef O_BINARY
-#define O_BINARY 0
-#endif
 
 extern  int    myargc;
 extern  char** myargv;
@@ -50,27 +41,27 @@ enum {
 
 // Bounding box functions.
 void M_ClearBox(fixed_t* box);
+void M_AddToBox(fixed_t* box, fixed_t x, fixed_t y);
 
-void
-M_AddToBox
-(fixed_t* box,
-	fixed_t    x,
-	fixed_t    y);
-
-boolean M_CreateDir(char* dirname);
-boolean M_WriteFile(char const* name, void* source, int length);
-int M_ReadFileEx(char const* name, byte** buffer, boolean use_malloc);
-int M_ReadFile(char const* name, byte** buffer);
-int M_FileExists(char* filename);
-long M_FileLengthFromPath(char const* filepath);
+// File functions
+boolean M_CreateDir(char* dirpath);
+boolean M_WriteFile(char* filepath, void* source, int length);
+int M_ReadFileEx(char* filepath, byte** buffer, boolean use_malloc);
+int M_ReadFile(char* filepath, byte** buffer);
+boolean M_RemoveFile(char* filepath);
+int M_FileExists(char* filepath);
+char* M_FileExistsInDirectory(char* dirpath, char* filename, boolean log);
+long M_FileLengthFromPath(char* filepath);
 long M_FileLength(FILE* handle);
-boolean M_WriteTextFile(char const* name, char* source, int length);
+boolean M_MoveFile(char* filename, char* src_dirpath, char* dst_dirpath);
+boolean M_WriteTextFile(char* filepath, char* source, int length);
+
 void M_ScreenShot(void);
 int M_CacheThumbNail(byte** data);
 void M_LoadDefaults(void);
 void M_SaveDefaults(void);
-bool M_StringCopy(char* dest, const char* src, unsigned int dest_size);
-char* M_StringDuplicate(const char* orig);
+bool M_StringCopy(char* dest, char* src, unsigned int dest_size);
+char* M_StringDuplicate(char* orig);
 
 //
 // DEFAULTS
@@ -82,6 +73,5 @@ extern int      viewheight;
 
 extern char* chat_macros[];
 
-//extern boolean HighSound;
 
 #endif

--- a/src/engine/p_saveg.c
+++ b/src/engine/p_saveg.c
@@ -56,6 +56,7 @@ static uint64_t save_offset = 0;
 // P_GetSaveGameName
 //
 
+// must be freed by caller
 char* P_GetSaveGameName(int num) {
     char name[256];
 

--- a/src/engine/sc_main.c
+++ b/src/engine/sc_main.c
@@ -43,7 +43,7 @@ static void SC_Open(const char* name) {
 	lump = W_CheckNumForName(name);
 
 	if (lump <= -1) {
-		sc_parser.buffsize = M_ReadFile(name, &sc_parser.buffer);
+		sc_parser.buffsize = M_ReadFile((char *)name, &sc_parser.buffer);
 
 		if (sc_parser.buffsize == -1) {
 			I_Error("SC_Open: %s not found", name);

--- a/src/engine/w_wad.h
+++ b/src/engine/w_wad.h
@@ -56,5 +56,6 @@ int             W_MapLumpLength(int lump);
 void* W_CacheLumpNum(int lump, int tag);
 void* W_CacheLumpName(const char* name, int tag);
 void W_KPFInit(void);
+boolean W_KPFLoadInner(char* kpf, const char* inner, unsigned char** data, int* size, int max_uncompressed, unsigned int* kpf_key);
 
 #endif

--- a/src/engine/z_zone.c
+++ b/src/engine/z_zone.c
@@ -127,6 +127,9 @@ void Z_Init(void) {
 //
 
 void (Z_Free)(void* ptr, const char* file, int line) {
+
+	if (!ptr) return; // to have the same semantics than free() which does nothing on NULL argument
+
 	memblock_t* block;
 
 	block = (memblock_t*)((byte*)ptr - sizeof(memblock_t));


### PR DESCRIPTION
Fixes #404 (issue not found)

**User data files**

- Windows was notably storing user data (config.cfg, screenshots, saves) in the install directory (where the .exe is found) which was not guaranteed to be writable and not best practice. Now user data files are written in the path returned by `SDL_GetPrefsPath()` which on Windows is `C:\Users\<username>\AppData\Roaming\doom64ex-plus`.
Updating from v4.2.0.0 and prior should be seamless as **existing data files in the executable directory are moved to the new directory**.

- if `SDL_GetPrefPath()` fails (returns `NULL`, which should not happen) this is a fatal error, which largely simplifies the calling code

- user data dir and config file path is logged in the console

- fix screenshots that were always written in the current directory  (!)

- saving a screenshot shows its full path in the console so you do not have to guess

**KPF**

- The `-kpf` command-line switch now accepts a path to a filesystem directory holding data files (PNG and localizations) with the same relative paths  that are would normally be embedded in a kpf file. This is useful for mods that are patching the kpf (with a .BAT file, only possible on Windows!) that now can be played without patching the kpf.
For example with [Doom 64 reloaded](https://www.moddb.com/games/doom-64/downloads/doom64-reloaded-01-09-2023), if you unzip the mod to a folder (let's say <modfolder>) you can play it with the custom kpf graphics this way:

```
DOOM64Ex-Plus -file <modfolder>/DOOM64RR.wad -kpf <modfolder>/kpf/Doom64
```

Whether all the maps render and play fine, that's another story but that's a start !

- the stock `Doom64.kpf` is always added last to the list of kpf. If nothing is specified, then it is the only file.

- added `-no-kpf-cache` because why not

**Other**

- Refactor some functions dealing with files and folders. Added new helpers

- some code cleanups

Hopefully nothing is broken. Hopefully !
