### PR TITLE
fix heap-use-after-free when going back to main menu with automap active

### DIFF
--- a/src/engine/d_main.c
+++ b/src/engine/d_main.c
@@ -899,8 +899,9 @@ static void D_Init(void) {
 
 	p = M_CheckParm("-loadgame");
 	if (p && p < myargc - 1) {
-		// sprintf(file, SAVEGAMENAME"%c.dsg",myargv[p+1][0]);
-		G_LoadGame(P_GetSaveGameName(myargv[p + 1][0] - '0'));
+		char *filepath = P_GetSaveGameName(myargv[p + 1][0] - '0');
+		G_LoadGame(filepath);
+		free(filepath);
 		autostart = true; // 20120105 bkw: this was missing
 	}
 

--- a/src/engine/p_tick.c
+++ b/src/engine/p_tick.c
@@ -330,12 +330,12 @@ void P_Stop(void) {
 		ST_ClearDamageMarkers();
 	}
 
-	// free level tags
-	Z_FreeTags(PU_LEVEL, PU_PURGELEVEL - 1);
-
 	if (automapactive) {
 		AM_Stop();
 	}
+
+	// free level tags
+	Z_FreeTags(PU_LEVEL, PU_PURGELEVEL - 1);
 
 	// music continues on exit if defined
 	if (!P_GetMapInfo(gamemap)->contmusexit) {


### PR DESCRIPTION
Found a bit by luck after getting:

```
=================================================================
==85216==ERROR: AddressSanitizer: heap-use-after-free on address 0x7e011a42e12a at pc 0x0000004d80f2 bp 0x7ffeb55408c0 sp 0x7ffeb55408b8
WRITE of size 1 at 0x7e011a42e12a thread T0
    #0 0x0000004d80f1 in R_SetLightFactor src/engine/r_lights.c:223
    #1 0x0000004d3824 in P_Stop src/engine/p_tick.c:337
    #2 0x00000041aaf7 in D_MiniLoop src/engine/d_main.c:424
    #3 0x00000042dcd6 in G_RunGame src/engine/g_game.c:1528
    #4 0x00000041c691 in D_DoomMain src/engine/d_main.c:1001
    #5 0x00000040876e in main src/engine/i_main.c:450
    #6 0x7ff11aa2b2fa in __libc_start_call_main (/lib64/libc.so.6+0x2b2fa) (BuildId: c2df7a1e82bbffe5ecf1c4ef204438764d22d728)
    #7 0x7ff11aa2b3ca in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2b3ca) (BuildId: c2df7a1e82bbffe5ecf1c4ef204438764d22d728)
    #8 0x000000408964 in _start ../sysdeps/x86_64/start.S:115

0x7e011a42e12a is located 42 bytes inside of 4792-byte region [0x7e011a42e100,0x7e011a42f3b8)
freed by thread T0 here:
    #0 0x7ff11b3208eb  (/lib64/libasan.so.8+0x1208eb) (BuildId: 281c22fa37162985ded2fec4683f599978edf10d)
    #1 0x00000061b72c in Z_FreeTags src/engine/z_zone.c:374
    #2 0x0000004d360d in P_Stop src/engine/p_tick.c:334
    #3 0x00000041aaf7 in D_MiniLoop src/engine/d_main.c:424
    #4 0x00000042dcd6 in G_RunGame src/engine/g_game.c:1528
    #5 0x00000041c691 in D_DoomMain src/engine/d_main.c:1001
    #6 0x00000040876e in main src/engine/i_main.c:450
    #7 0x7ff11aa2b2fa in __libc_start_call_main (/lib64/libc.so.6+0x2b2fa) (BuildId: c2df7a1e82bbffe5ecf1c4ef204438764d22d728)
    #8 0x7ffeb5542453  ([stack]+0x20453)

previously allocated by thread T0 here:
    #0 0x7ff11b321c2b in malloc (/lib64/libasan.so.8+0x121c2b) (BuildId: 281c22fa37162985ded2fec4683f599978edf10d)
    #1 0x00000061aeb8 in Z_Malloc src/engine/z_zone.c:238
    #2 0x0000004be46f in P_LoadLights src/engine/p_setup.c:344
    #3 0x0000004c3381 in P_SetupLevel src/engine/p_setup.c:990
    #4 0x00000042d596 in G_DoLoadLevel src/engine/g_game.c:987
    #5 0x00000042dcb4 in G_RunGame src/engine/g_game.c:1521
    #6 0x00000041c691 in D_DoomMain src/engine/d_main.c:1001
    #7 0x00000040876e in main src/engine/i_main.c:450
    #8 0x7ff11aa2b2fa in __libc_start_call_main (/lib64/libc.so.6+0x2b2fa) (BuildId: c2df7a1e82bbffe5ecf1c4ef204438764d22d728)
    #9 0x7ffeb5542453  ([stack]+0x20453)

SUMMARY: AddressSanitizer: heap-use-after-free src/engine/r_lights.c:223 in R_SetLightFactor
```
