### PR TITLE
better scale default for crosshair on HiRes screens

### DIFF
--- a/src/engine/con_console.c
+++ b/src/engine/con_console.c
@@ -32,6 +32,9 @@
 #include "gl_draw.h"
 #include "i_system.h"
 #include "dgl.h"
+#include "i_video.h"
+#include "i_shaders.h"
+
 
 #define SDL_MAIN_HANDLED
 
@@ -454,8 +457,6 @@ boolean CON_Responder(event_t* ev) {
 //
 // CON_Draw
 //
-
-extern float display_scale; // set in i_video.c
 
 #define CONFONT_SCALE   ((display_scale * SCREENHEIGHT) / video_height)
 

--- a/src/engine/gl_main.c
+++ b/src/engine/gl_main.c
@@ -30,6 +30,7 @@
 #include "doomdef.h"
 #include "doomstat.h"
 #include "i_system.h"
+#include "i_video.h"
 #include "z_zone.h"
 #include "r_main.h"
 #include "gl_texture.h"
@@ -63,8 +64,6 @@ CVAR_EXTERNAL(r_anisotropic);
 CVAR_EXTERNAL(r_multisample);
 CVAR_EXTERNAL(st_flashoverlay);
 CVAR_EXTERNAL(r_colorscale);
-
-extern int win_px_w, win_px_h;
 
 void GL_OnResize(int w, int h);
 

--- a/src/engine/i_video.h
+++ b/src/engine/i_video.h
@@ -31,4 +31,7 @@ void I_InitScreen(void);
 void I_ShutdownVideo(void);
 void V_RegisterCvars();
 
+extern float display_scale;
+extern int win_px_w, win_px_h;
+
 #endif

--- a/src/engine/m_misc.c
+++ b/src/engine/m_misc.c
@@ -347,6 +347,8 @@ void M_LoadDefaults(void) {
 // M_ScreenShot
 //
 
+#
+
 void M_ScreenShot(void) {
 	filepath_t name;
 	byte* buff;
@@ -364,8 +366,9 @@ void M_ScreenShot(void) {
 
 	if (png && M_WriteFile(name, png, size)) {
 		I_Printf("Saved screenshot: %s\n", name);
+		players[consoleplayer].message = "Saved screenshot";
 	} else {
-		I_Printf("Failed to create screenshot\n");
+		players[consoleplayer].message = "Failed to create screenshot";
 	}
 
 	Z_Free(png);

--- a/src/engine/st_stuff.c
+++ b/src/engine/st_stuff.c
@@ -48,6 +48,7 @@
 #include "i_swap.h"
 #include "w_wad.h"
 #include "i_shaders.h"
+#include "i_video.h"
 
 void M_DrawXInputButton(int x, int y, int button);
 
@@ -691,6 +692,7 @@ void ST_DrawCrosshair(int x, int y, int slot, byte scalefactor, rcolor color) {
 	dglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
 	u = 1.0f / st_crosshairs;
+
 	scale = scalefactor == 0 ? ST_CROSSHAIRSIZE : (ST_CROSSHAIRSIZE / (1 << scalefactor));
 
 	GL_SetupAndDraw2DQuad((float)x, (float)y, scale, scale,
@@ -943,7 +945,13 @@ void ST_Drawer(void) {
 			alpha = 0;
 		}
 
-		ST_DrawCrosshair(x, y, (int)st_crosshair.value, 2, WHITEALPHA(alpha));
+		// nominal scale value for 1080p is 2
+		// for [1080p; 1620p[ => 2
+		// for [1620p; 2640p[ => 3
+
+		int scale = 1 + SDL_lroundf(win_px_h / 1080.f);
+
+		ST_DrawCrosshair(x, y, (int)st_crosshair.value, scale, WHITEALPHA(alpha));
 	}
 
 	//

--- a/src/engine/w_wad.c
+++ b/src/engine/w_wad.c
@@ -34,6 +34,7 @@
 #include "doomstat.h"
 #include "i_system.h"
 #include "i_system_io.h"
+#include "i_video.h"
 #include "z_zone.h"
 #include "m_misc.h"
 #include "md5.h"
@@ -56,8 +57,6 @@ typedef struct memlump_s {
 
 static memlump_t g_memlumps[MAX_MEMLUMPS];
 static int g_nmemlumps = 0;
-
-extern int win_px_w, win_px_h;
 
 char* g_kpf_files[MAX_KPF_FILES];
 int g_num_kpf = 0;


### PR DESCRIPTION
- Crosshair was too big on 4K screen. Now it should have the same size than on a 1080p monitor.
Ideally I think we should make crosshair size user configurable and in finer steps. Color would be nice as well

- taking a screenshot displays a "Saved screenshot" message on top of screen