### PR TITLE
fix nightmare difficulty (-skill 5) and -respawn not respawning monsters at correct location

### DIFF
--- a/src/engine/p_mobj.c
+++ b/src/engine/p_mobj.c
@@ -1058,6 +1058,9 @@ mobj_t* P_SpawnMapThing(mapthing_t* mthing) {
 	mobj->z += (mthing->z << FRACBITS);
 	mobj->angle = ANG45 * (mthing->angle / 45);
 	mobj->tid = mthing->tid;
+	if (respawnmonsters) {
+		mobj->spawnpoint = *mthing;
+	}
 
 	//
 	// [d64] check if spawn is valid


### PR DESCRIPTION
When starting the game with either `-skill 5` (nightmare or Hardcode difficulty mode) or any difficulty with `-respawn`,
monsters where respawning but always at (0, 0, 0).
Now they respawn where they should !