### PR TITLE
fix instances of mobj target / tracer not refcounted

### DIFF
--- a/src/engine/p_enemy.c
+++ b/src/engine/p_enemy.c
@@ -1871,7 +1871,7 @@ void A_SkelMissile(mobj_t* actor, int direction)
 		true);
 	mo->x += mo->momx;
 	mo->y += mo->momy;
-	mo->tracer = actor->target;
+	P_SetTarget(&mo->tracer, actor->target);
 }
 
 //
@@ -2107,7 +2107,7 @@ void A_VileChase(mobj_t* actor)
 					corpsehit->height <<= 2;
 					corpsehit->flags = info->flags;
 					corpsehit->health = info->spawnhealth;
-					corpsehit->target = NULL;
+					P_SetTarget(&corpsehit->target, NULL);
 
 					return;
 				}
@@ -2145,9 +2145,9 @@ void A_VileTarget(mobj_t* actor)
 		actor->target->x,
 		actor->target->z, MT_FIRE);
 
-	actor->tracer = fog;
-	fog->target = actor;
-	fog->tracer = actor->target;
+	P_SetTarget(&actor->tracer, fog);
+	P_SetTarget(&fog->target, actor);
+	P_SetTarget(&fog->tracer, actor->target);
 	A_Fire(fog);
 }
 

--- a/src/engine/p_inter.c
+++ b/src/engine/p_inter.c
@@ -1137,7 +1137,7 @@ void P_DamageMobj(mobj_t* target, mobj_t* inflictor, mobj_t* source, int damage)
 	target->reactiontime = 0; /* we're awake now...	 */
 	if (!target->threshold && source && (source->flags & MF_SHOOTABLE) && !(target->flags & MF_NOINFIGHTING))
 	{	/* if not intent on another player, chase after this one */
-		target->target = source;
+		P_SetTarget(&target->target, source);
 		target->threshold = BASETHRESHOLD;
 		if (target->state == &states[target->info->spawnstate] && target->info->seestate != S_NULL)
 		{


### PR DESCRIPTION
Fixes #314 #406

Finally fixed that one !

- `p_inter.c` was assigning a mobj's target instead of using `P_SetTarget` to refcount it. Hence the use after free.
- Also use `P_SetTarget` to assign mobj `tracer` field for non-standard monsters.