### PR TITLE
fix loading MAPINFO lump from PWADS and misc cheats cleanup

### DIFF
--- a/src/engine/g_game.c
+++ b/src/engine/g_game.c
@@ -97,6 +97,9 @@ static boolean savenow = false;
 static int      savegameflags = 0;
 static int      savecompatflags = 0;
 
+const int title_map_num = 33;
+
+
 // for intermission
 boolean        precache = true;     // if true, load all graphics at start
 
@@ -1443,7 +1446,9 @@ void G_ExitLevel(void) {
 
 	P_SpawnDelayTimer(&junk, G_CompleteLevel);
 
-	nextmap = gamemap + 1;
+	if (gamemap != title_map_num) {
+		nextmap = gamemap + 1;
+	}
 }
 
 //
@@ -1469,27 +1474,14 @@ void G_SecretExitLevel(int map) {
 //
 
 void G_RunTitleMap(void) {
-	int alpha_title_map = M_CheckParm("-alpha");
-	// villsa 12092013 - abort if map doesn't exist in mapfino
-	if (!alpha_title_map && P_GetMapInfo(33) == NULL) {
-		return;
-	}
-	else if (alpha_title_map && P_GetMapInfo(30) == NULL) {
-		return;
-	}
 
+	if (!P_GetMapInfo(title_map_num)) return;
+	
 	demobuffer = (byte*)Z_Calloc(0x16000, PU_STATIC, NULL);
 	demo_p = demobuffer;
 	demobuffer[0x16000 - 1] = DEMOMARKER;
 
-	if (!alpha_title_map)
-	{
-		G_InitNew(sk_medium, 33);
-	}
-	else if (alpha_title_map)
-	{
-		G_InitNew(sk_medium, 30);
-	}
+	G_InitNew(sk_medium, title_map_num);
 
 	precache = true;
 	usergame = false;
@@ -1543,7 +1535,7 @@ void G_RunGame(void) {
 			next = D_MiniLoop(WI_Start, WI_Stop, WI_Drawer, WI_Ticker);
 		}
 
-		if (next == ga_victory) {
+		if (next == ga_victory && gamemap != title_map_num) {
 			next = D_MiniLoop(IN_Start, IN_Stop, IN_Drawer, IN_Ticker);
 
 			if (next == ga_finale) {

--- a/src/engine/g_game.h
+++ b/src/engine/g_game.h
@@ -48,4 +48,6 @@ void G_RegisterCvars(void);
 
 boolean G_Responder(event_t* ev);
 
+extern const int title_map_num;
+
 #endif

--- a/src/engine/i_png.c
+++ b/src/engine/i_png.c
@@ -262,6 +262,8 @@ byte* I_PNGReadData(int lump, bool palette, bool nopack, bool alpha,
         return NULL;
     }
 
+    png_set_crc_action(png_ptr, PNG_CRC_NO_CHANGE, PNG_CRC_QUIET_USE);
+
     png_set_read_fn(png_ptr, NULL, I_PNGReadFunc);
 
     if (offset) {

--- a/src/engine/p_inter.c
+++ b/src/engine/p_inter.c
@@ -618,7 +618,7 @@ void P_TouchSpecialThing(mobj_t* special, mobj_t* toucher) {
 		if (!P_GiveAmmo(player, am_shell, 1)) {
 			return;
 		}
-		player->message = (gameskill == sk_baby) ? GOTSHELLS2 : GOTSHELLS;    //villsa
+		player->message = (gameskill == sk_baby || gameskill == sk_nightmare) ? GOTSHELLS2 : GOTSHELLS;    //villsa
 		player->messagepic = 13;
 		break;
 

--- a/src/engine/w_merge.c
+++ b/src/engine/w_merge.c
@@ -342,11 +342,15 @@ static void DoMerge(void)
     newlumps = (lumpinfo_t*)malloc(sizeof(lumpinfo_t) * numlumps);
     num_newlumps = 0;
 
+
     // IWAD
     current_section = SECTION_NORMAL;
 
     for (i = 0; i < iwad.numlumps; ++i) {
         lumpinfo_t* lump = &iwad.lumps[i];
+
+        // will load it later from PWAD
+        if (dstreq(lump->name, "MAPINFO") && FindInPWAD(lump->name)) continue;
 
         if (lump->name[0] == 'M' && lump->name[1] == 'A' && lump->name[2] == 'P' &&
             lump->name[3] >= '0' && lump->name[3] <= '9' &&
@@ -479,6 +483,12 @@ static void DoMerge(void)
     for (i = 0; i < pwad.numlumps; ++i) {
         lumpinfo_t* lump = &pwad.lumps[i];
 
+        if (dstreq(lump->name, "MAPINFO")) {
+            // might not be in SECTION_NORMAL so take care of it separately
+            newlumps[num_newlumps++] = *lump;
+            continue;
+        }
+
         if (lump->name[0] == 'M' && lump->name[1] == 'A' && lump->name[2] == 'P' &&
             lump->name[3] >= '0' && lump->name[3] <= '9' &&
             lump->name[4] >= '0' && lump->name[4] <= '9')
@@ -580,9 +590,7 @@ void W_MergeFile(char* filename) {
 
 	// Load PWAD
 
-	if (W_AddFile(filename) == NULL) {
-		return;
-	}
+	if (!W_AddFile(filename)) return;
 
 	// iwad is at the start, pwad was appended to the end
 

--- a/src/engine/w_wad.c
+++ b/src/engine/w_wad.c
@@ -134,6 +134,27 @@ unsigned int W_HashLumpName(const char* str) {
 // W_HashLumps
 //
 
+//
+// W_CheckNumForName
+// Returns -1 if name not found.
+//
+
+int W_CheckNumForName(const char* name) {
+	int i = -1;
+
+	if (numlumps) {
+		i = lumpinfo[W_HashLumpName(name) % numlumps].index;
+	}
+
+	while (i >= 0 && dstrncmp(lumpinfo[i].name, name, 8)) {
+		i = lumpinfo[i].next;
+	}
+
+
+	return i;
+}
+
+
 static void W_HashLumps(void) {
 	int i;
 	unsigned int hash;
@@ -242,8 +263,6 @@ wad_file_t* W_AddFile(char* filename) {
 
 	Z_Free(fileinfo);
 
-	W_HashLumps();
-
 	return wadfile;
 }
 
@@ -349,6 +368,7 @@ void W_Init(void) {
 		}
 	}
 
+	// only need to hash lumps when they are all loaded and before W_KPFInit()
 	W_HashLumps();
 		
 	I_Printf("W_KPFInit: Init KPFfiles.\n");
@@ -457,24 +477,6 @@ void* W_GetMapLump(int lump) {
 	return (mapLumpData + LONG(mapLump[lump].filepos));
 }
 
-//
-// W_CheckNumForName
-// Returns -1 if name not found.
-//
-
-int W_CheckNumForName(const char* name) {
-	int i = -1;
-
-	if (numlumps) {
-		i = lumpinfo[W_HashLumpName(name) % numlumps].index;
-	}
-
-	while (i >= 0 && dstrncmp(lumpinfo[i].name, name, 8)) {
-		i = lumpinfo[i].next;
-	}
-
-	return i;
-}
 
 //
 // W_GetNumForName


### PR DESCRIPTION
**MAPINFO**

- when merging, always add only the MAPINFO from the merged PWAD if it has one. This fixes at least Doom 64 Reloaded Remastered (correct map info + intermission text working). Also tested with BETA64 and Ethereal. These WAD probably have other problems (notably episode selection does not work)  but at least display the proper map info 
- Hash lumps only once after all WADs have been merged

**cheats**

- removed `idnull` which is obsolete
- `exclev` and `idclev` can warp to any valid map, including  map 33 (title map) that does not crash anymore


**misc**

- removed osbolete `-alpha` command-line option
- i_png.c: disable libpng chunk CRC warning spam on stdout. Doom 64 Reloaded Remastered has plenty of these in `grAb` chunks that are benign
- other small cleanups
