### PR TITLE
misc small improvements and refactors

### DIFF
--- a/src/engine/d_main.c
+++ b/src/engine/d_main.c
@@ -484,53 +484,9 @@ static void Title_Stop(void) {
 	S_StopMusic();
 }
 
-//
-// Legal_Start
-//
-
-CVAR_EXTERNAL(p_regionmode);
-
-static char* legalpic = "USLEGAL";
-static int legal_x = 32;
-static int legal_y = 72;
-
-static void Legal_Start(void) {
-	int pllump;
-	int jllump;
-
-	pllump = W_CheckNumForName("PLLEGAL");
-	jllump = W_CheckNumForName("JPLEGAL");
-
-	if (pllump == -1 && jllump == -1) {
-		return;
-	}
-
-	if (p_regionmode.value >= 2 && jllump >= 0) {
-		legalpic = "JPLEGAL";
-		legal_x = 35;
-		legal_y = 45;
-	}
-	else if (p_regionmode.value >= 2 && jllump == -1) {
-		CON_CvarSetValue(p_regionmode.name, 1);
-	}
-
-	if (p_regionmode.value == 1 && pllump >= 0) {
-		legalpic = "PLLEGAL";
-		legal_x = 35;
-		legal_y = 50;
-	}
-	else if (p_regionmode.value == 1 && pllump == -1) {
-		CON_CvarSetValue(p_regionmode.name, 0);
-	}
-}
-
-//
-// Legal_Drawer
-//
-
 static void Legal_Drawer(void) {
 	GL_ClearView(0xFF000000);
-	Draw_GfxImageLegal(legal_x, legal_y, legalpic, WHITE, true);
+	Draw_GfxImageLegal(32, 72, "USLEGAL", WHITE, true);
 }
 
 //
@@ -699,7 +655,7 @@ static void D_SplashScreen(void) {
 	pagetic = gametic;
 	gameaction = ga_nothing;
 
-	skip = D_MiniLoop(Legal_Start, NULL, Legal_Drawer, Legal_Ticker);
+	skip = D_MiniLoop(NULL, NULL, Legal_Drawer, Legal_Ticker);
 
 	if (skip != ga_title) {
 		G_RunTitleMap();
@@ -915,6 +871,10 @@ static void D_Init(void) {
 //
 
 static int D_CheckDemo(void) {
+
+	// Demo recording / playback is broken (crashes) so disable it for now
+
+	/*
 	int p;
 
 	// start the apropriate game based on parms
@@ -931,6 +891,7 @@ static int D_CheckDemo(void) {
 		G_PlayDemo(myargv[p + 1]);
 		return 1;
 	}
+	*/
 
 	return 0;
 }

--- a/src/engine/gl_draw.c
+++ b/src/engine/gl_draw.c
@@ -42,81 +42,53 @@ CVAR_EXTERNAL(r_hudFilter);
 //
 // Draw_GfxImage
 //
+static const int nominal_width = 320.0f;
 
-void Draw_GfxImage(int x, int y, const char* name, rcolor color, boolean alpha) {
+static void Draw_GfxImageInternal(int x, int y, const char* name, 
+	float max_w, float offset_width, float offset_height, 
+	rcolor color, boolean alpha) {
+	
 	int gfxIdx = GL_BindGfxTexture(name, alpha);
+	float imgWidth = gfxwidth[gfxIdx];
+	float imgHeight = gfxheight[gfxIdx];
+	float scale;
 
 	dglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	dglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
+	if (max_w > 0.0f) {
+		float targetSize = fmin(max_w, fmin(imgWidth, imgHeight));
+		scale = targetSize / fmax(imgWidth, imgHeight);
+	} else {
+		scale = 1.0f;
+	}
+
 	GL_SetState(GLSTATE_BLEND, 1);
-	GL_SetupAndDraw2DQuad((float)x, (float)y,
-		gfxwidth[gfxIdx], gfxheight[gfxIdx], 0, 1.0f, 0, 1.0f, color, 0);
+	GL_SetupAndDraw2DQuad((float)x - offset_width, (float)y - offset_height,
+		imgWidth * scale, imgHeight * scale, 0, 1.0f, 0, 1.0f, color, 0);
 
 	GL_SetState(GLSTATE_BLEND, 0);
+}
+
+
+void Draw_GfxImage(int x, int y, const char* name, rcolor color, boolean alpha) {
+	Draw_GfxImageInternal(x, y, name, -1.0f, 0.0f, 0.0f, color, alpha);
 }
 
 void Draw_GfxImageInter(int x, int y, const char* name, rcolor color, boolean alpha) {
-	int gfxIdx = GL_BindGfxTexture(name, alpha);
-
-	dglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	dglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-	float imgWidth = gfxwidth[gfxIdx];
-	float imgHeight = gfxheight[gfxIdx];
-	float targetSize = fmin(250.0f, fmin(imgWidth, imgHeight));
-	float scale = targetSize / fmax(imgWidth, imgHeight);
-
-	float offset_width = 5.0f;
-	float offset_height = 5.0f;
-
-	GL_SetState(GLSTATE_BLEND, 1);
-	GL_SetupAndDraw2DQuad((float)x - offset_width, (float)y - offset_height,
-		imgWidth * scale, imgHeight * scale, 0, 1.0f, 0, 1.0f, color, 0);
-
-	GL_SetState(GLSTATE_BLEND, 0);
+	Draw_GfxImageInternal(x, y, name, 250.0f, 5.0f, 5.0f, color, alpha);
 }
 
 void Draw_GfxImageLegal(int x, int y, const char* name, rcolor color, boolean alpha) {
-	int gfxIdx = GL_BindGfxTexture(name, alpha);
+	Draw_GfxImageInternal(x, y, name, nominal_width, 30.0f, 40.0f, color, alpha);
+}
 
-	dglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	dglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-	float imgWidth = gfxwidth[gfxIdx];
-	float imgHeight = gfxheight[gfxIdx];
-	float targetSize = fmin(320.0f, fmin(imgWidth, imgHeight));
-	float scale = targetSize / fmax(imgWidth, imgHeight);
-
-	float offset_width = 30.0f;
-	float offset_height = 40.0f;
-
-	GL_SetState(GLSTATE_BLEND, 1);
-	GL_SetupAndDraw2DQuad((float)x - offset_width, (float)y - offset_height,
-		imgWidth * scale, imgHeight * scale, 0, 1.0f, 0, 1.0f, color, 0);
-
-	GL_SetState(GLSTATE_BLEND, 0);
+void Draw_GfxImageIN(int x, int y, const char* name, rcolor color, boolean alpha) {
+	Draw_GfxImageInternal(x, y, name, nominal_width, 0.0f, 0.0f, color, alpha);
 }
 
 void Draw_GfxImageTitle(int x, int y, const char* name, rcolor color, boolean alpha) {
-	int gfxIdx = GL_BindGfxTexture(name, alpha);
-
-	dglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	dglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-	float imgWidth = gfxwidth[gfxIdx];
-	float imgHeight = gfxheight[gfxIdx];
-	float targetSize = fmin(320.0f, fmin(imgWidth, imgHeight));
-	float scale = targetSize / fmax(imgWidth, imgHeight);
-
-	float offset_width = 60.0f;
-	float offset_height = 30.0f;
-
-	GL_SetState(GLSTATE_BLEND, 1);
-	GL_SetupAndDraw2DQuad((float)x - offset_width, (float)y - offset_height,
-		imgWidth * scale, imgHeight * scale, 0, 1.0f, 0, 1.0f, color, 0);
-
-	GL_SetState(GLSTATE_BLEND, 0);
+	Draw_GfxImageInternal(x, y, name, nominal_width, 60.0f, 30.0f, color, alpha);
 }
 
 //

--- a/src/engine/gl_draw.h
+++ b/src/engine/gl_draw.h
@@ -28,6 +28,8 @@ void Draw_GfxImageInter(int x, int y, const char* name,
 	rcolor color, boolean alpha);
 void Draw_GfxImageLegal(int x, int y, const char* name,
 	rcolor color, boolean alpha);
+void Draw_GfxImageIN(int x, int y, const char* name,
+	rcolor color, boolean alpha);
 void Draw_Sprite2D(int type, int rot, int frame, int x, int y,
 	float scale, int pal, rcolor c);
 

--- a/src/engine/i_system.c
+++ b/src/engine/i_system.c
@@ -273,7 +273,7 @@ static char* FindDataFile(char* file) {
 	return NULL;
 }
 
-// return a full qualified path or NULL that is cached and that must NOT be freed by caller
+// return a full qualified path that is cached, or NULL if not found. Must NOT be freed by caller
 char* I_FindDataFile(char* file) {
 
 	typedef struct {

--- a/src/engine/in_stuff.c
+++ b/src/engine/in_stuff.c
@@ -128,7 +128,7 @@ void IN_Drawer(void) {
 	}
 
 	// Draw background
-	Draw_GfxImage(fcluster->pic_x, fcluster->pic_y, fcluster->pic, color, false);
+	Draw_GfxImageIN(fcluster->pic_x, fcluster->pic_y, fcluster->pic, color, false);
 
 	if (!fInterFadeOut) {
 		// don't draw anything else until background is fully opaque

--- a/src/engine/m_misc.c
+++ b/src/engine/m_misc.c
@@ -393,3 +393,14 @@ int M_CacheThumbNail(byte** data) {
 	*data = tbn;
 	return SAVEGAMETBSIZE;
 }
+
+
+unsigned int M_StringHash(char* str) {
+	unsigned int hash = 1315423911;
+
+	for ( ; *str != '\0'; str++) {
+		hash ^= ((hash << 5) + SDL_toupper((int)*str) + (hash >> 2));
+	}
+
+	return hash;
+}

--- a/src/engine/m_misc.h
+++ b/src/engine/m_misc.h
@@ -62,6 +62,7 @@ int M_CacheThumbNail(byte** data);
 void M_LoadDefaults(void);
 void M_SaveDefaults(void);
 char* M_StringDuplicate(char* orig);
+unsigned int M_StringHash(char* str);
 
 //
 // DEFAULTS

--- a/src/engine/p_mapinfo.c
+++ b/src/engine/p_mapinfo.c
@@ -226,21 +226,15 @@ static boolean LOC_LoadLang(int lang) {
     const char* want_inner = LOC_LangPath(lang);
     unsigned char* data = NULL; int size = 0;
 
-    for (int i = 0; i < g_num_kpf; ++i) {
-
-        char* kpf_path = g_kpf_files[i];
-
-        if (W_KPFLoadInner(kpf_path, want_inner, &data, &size, 0, NULL)) {
-            LOC_LoadFromBuffer(data, size);
-            free(data);
-            I_Printf("Localization: Loaded %d entries from %s in %s\n",
-                localisation_count, want_inner, kpf_path);
-            return true;
-        }
+    if (W_KPFLoadInner(want_inner, &data, &size)) {
+        LOC_LoadFromBuffer(data, size);
+        free(data);
+        I_Printf("Localization: Loaded %d entries from %s\n",
+            localisation_count, want_inner);
+        return true;
     }
 
     return false;
-
 }
 
 void LOC_RegisterCvars(void) {
@@ -249,7 +243,7 @@ void LOC_RegisterCvars(void) {
 
 static void LOC_Load(void) {
     
-    int lang = p_language.value;
+    int lang = (int)p_language.value;
 
     if (LOC_LoadLang(lang)) return;
 

--- a/src/engine/p_setup.c
+++ b/src/engine/p_setup.c
@@ -98,7 +98,6 @@ CVAR(p_fdoubleclick, 0);
 CVAR(p_sdoubleclick, 0);
 CVAR(p_usecontext, 0);
 CVAR(p_damageindicator, 0);
-CVAR(p_regionmode, 0);
 
 //
 // [kex] sky definition stuff
@@ -1191,5 +1190,4 @@ void P_RegisterCvars(void) {
 	CON_CvarRegister(&p_sdoubleclick);
 	CON_CvarRegister(&p_usecontext);
 	CON_CvarRegister(&p_damageindicator);
-	CON_CvarRegister(&p_regionmode);
 }

--- a/src/engine/w_wad.h
+++ b/src/engine/w_wad.h
@@ -37,11 +37,6 @@ typedef struct {
 extern lumpinfo_t* lumpinfo;
 extern int numlumps;
 
-// "8 kpf ought to be enough for anybody"
-#define MAX_KPF_FILES 8
-extern char* g_kpf_files[MAX_KPF_FILES];
-extern int g_num_kpf;
-
 void            W_Init(void);
 wad_file_t* W_AddFile(char* filename);
 unsigned int    W_HashLumpName(const char* str);
@@ -55,7 +50,9 @@ void            W_FreeMapLump(void);
 int             W_MapLumpLength(int lump);
 void* W_CacheLumpNum(int lump, int tag);
 void* W_CacheLumpName(const char* name, int tag);
+boolean W_LumpNameEq(lumpinfo_t* lump, const char* name);
+
 void W_KPFInit(void);
-boolean W_KPFLoadInner(char* kpf, const char* inner, unsigned char** data, int* size, int max_uncompressed, unsigned int* kpf_key);
+boolean W_KPFLoadInner(const char* inner, unsigned char** data, int* size);
 
 #endif


### PR DESCRIPTION
Some work done so graphics in Ethereal load and display properly.

- removed `-playdemo` and `-record` command-line options as demo do not work properly and `-record` crashes
- removed `p_regionmode` CVAR, unused. Probably a left over of the ROM dump DOOM64.WAD era
- `Draw_GfxImage*` simplification
- png: if loading an image with alpha while requiring not alpha, convert it to RGB with alpha pre-multiplied. This was necessary to show properly Ethereal credit image shown before each level
- added `M_StringHash()`, a  general string hashing func
- `W_KPFLoadInner()` is now a simplified exported util function searching all kpfs
- merging WAD also search for `G_START` and `G_END` markers for graphics (Ethereal uses them)
- added `W_LumpNameEq()` function