### PR TITLE
misc tweaks

### DIFF
--- a/src/engine/con_console.c
+++ b/src/engine/con_console.c
@@ -63,7 +63,7 @@ static conline_t** console_buffer;
 static int          console_head;
 static int          console_lineoffset;
 static int          console_minline;
-static boolean     console_enabled = false;
+boolean			    console_enabled = false;
 static char         console_linebuffer[CON_BUFFERSIZE];
 static int          console_linelength;
 static boolean     console_state = CST_UP;

--- a/src/engine/con_console.h
+++ b/src/engine/con_console.h
@@ -30,7 +30,8 @@
 #define MAX_CONSOLE_INPUT_LEN    80
 extern char     console_inputbuffer[];
 extern int      console_inputlength;
-extern boolean console_initialized;
+extern boolean  console_initialized;
+extern boolean	console_enabled;
 
 #define CONCLEARINPUT() (dmemset(console_inputbuffer+1, 0, MAX_CONSOLE_INPUT_LEN-1))
 

--- a/src/engine/g_game.c
+++ b/src/engine/g_game.c
@@ -483,6 +483,11 @@ static CMD(Map) {
 		if (P_GetMapInfo(map)) {
 
 			if (gamestate == GS_LEVEL) {
+
+				if (menuactive) {
+					M_ClearMenus();
+				}
+
 				M_CheatWarp(NULL, param[0]);
 			}
 			else {
@@ -740,11 +745,12 @@ void G_BuildTiccmd(ticcmd_t* cmd) {
 
 		cmd->angleturn -= pc->mousex * 0x4;
 
-		if (forcefreelook != 2) {
-			if ((int)v_mlook.value || forcefreelook) {
-				cmd->pitch -= (int)v_mlookinvert.value ? pc->mousey * 0x4 : -(pc->mousey * 0x4);
-			}
+		
+		if (forcefreelook != 2 && ((int)v_mlook.value || forcefreelook)) {
+			cmd->pitch -= (int)v_mlookinvert.value ? pc->mousey * 0x4 : -(pc->mousey * 0x4);
 		}
+		
+		
 	}
 
 	if ((int)v_yaxismove.value) {

--- a/src/engine/g_game.c
+++ b/src/engine/g_game.c
@@ -968,7 +968,7 @@ static void G_SetGameFlags(void) {
 	if (sv_allowcheats.value > 0)   gameflags |= GF_ALLOWCHEATS;
 	if (sv_friendlyfire.value > 0)  gameflags |= GF_FRIENDLYFIRE;
 	if (sv_keepitems.value > 0)     gameflags |= GF_KEEPITEMS;
-	if (p_autoaim.value > 0)        gameflags |= GF_ALLOWAUTOAIM;
+	if (p_autoaim.value > 0 || v_mlook.value <= 0)  gameflags |= GF_ALLOWAUTOAIM; // force autoaim if mlook is disabled
 
 	if (compat_mobjpass.value > 0)  compatflags |= COMPATF_MOBJPASS;
 }

--- a/src/engine/i_sdlinput.c
+++ b/src/engine/i_sdlinput.c
@@ -48,10 +48,9 @@ CVAR_CMD(v_mlook, 0) {
 	if (gamestate == GS_LEVEL) {
 		players[0].mo->pitch = 0;
 	}
-	// force autoaim if off
-	if (p_autoaim.value <= 0) {
-		CON_CvarSetValue("p_autoaim", 1.0f);
-	}
+
+	// force autoaim
+	gameflags |= GF_ALLOWAUTOAIM;
 };
 
 

--- a/src/engine/i_sdlinput.c
+++ b/src/engine/i_sdlinput.c
@@ -34,11 +34,26 @@
 CVAR(v_msensitivityx, 5);
 CVAR(v_msensitivityy, 5);
 CVAR(v_macceleration, 0);
-CVAR(v_mlook, 0);
 CVAR(v_mlookinvert, 0);
 CVAR(v_yaxismove, 0);
 CVAR(v_xaxismove, 0);
 CVAR_EXTERNAL(m_menumouse);
+CVAR_EXTERNAL(p_autoaim);
+
+CVAR_CMD(v_mlook, 0) {
+	if (cvar->value > 0) return;
+	// mlook is disabled
+
+	// center player view, resetting pitch
+	if (gamestate == GS_LEVEL) {
+		players[0].mo->pitch = 0;
+	}
+	// force autoaim if off
+	if (p_autoaim.value <= 0) {
+		CON_CvarSetValue("p_autoaim", 1.0f);
+	}
+};
+
 
 float mouse_accelfactor;
 

--- a/src/engine/m_menu.c
+++ b/src/engine/m_menu.c
@@ -187,7 +187,6 @@ extern menu_t ControlMenuDef;
 //------------------------------------------------------------------------
 
 void M_SetupNextMenu(menu_t* menudef);
-void M_ClearMenus(void);
 
 void M_QuickSave(void);
 void M_QuickLoad(void);

--- a/src/engine/m_menu.h
+++ b/src/engine/m_menu.h
@@ -50,4 +50,6 @@ void M_StartMainMenu(void);
 
 void M_RegisterCvars(void);
 
+void M_ClearMenus(void);
+
 #endif

--- a/src/engine/p_user.c
+++ b/src/engine/p_user.c
@@ -281,7 +281,6 @@ void P_CalcHeight(player_t* player) {
 //
 // P_MovePlayer
 //
-
 void P_MovePlayer(player_t* player) {
     ticcmd_t* cmd;
     int         mpitch;

--- a/src/engine/r_sky.c
+++ b/src/engine/r_sky.c
@@ -1104,7 +1104,7 @@ void R_DrawSky(void) {
         if (r_skybox <= 0) {
             R_DrawSimpleSky(skybackdropnum, 170);
         }
-        else {
+        else if(skybackdropnum != -1) {
             float h;
             float origh;
             int l;

--- a/src/engine/r_wipe.c
+++ b/src/engine/r_wipe.c
@@ -25,8 +25,7 @@
 #include "gl_texture.h"
 #include "doomstat.h"
 #include "dgl.h"
-
-void M_ClearMenus(void);    // from m_menu.c
+#include "m_menu.h"
 
 static dtexture wipeMeltTexture = 0;
 static int wipeFadeAlpha = 0;

--- a/src/engine/st_stuff.c
+++ b/src/engine/st_stuff.c
@@ -937,7 +937,7 @@ void ST_Drawer(void) {
 	// draw crosshairs
 	//
 
-	if (st_crosshairs && !automapactive) {
+	if (st_crosshairs && !(automapactive || menuactive || console_enabled)) {
 		int x = (SCREENWIDTH / 2) - (ST_CROSSHAIRSIZE / 8);
 		int y = (SCREENHEIGHT / 2) - (ST_CROSSHAIRSIZE / 8);
 		int alpha = (int)st_crosshairopacity.value;


### PR DESCRIPTION
- when issuing map console command while already in a map and a menu is displayed, dismiss the menu
- switching mlook from enabled to disabled centers the view
- if mlook is disabled, force autoaim enabled (without altering the p_autoaim variable)
- do not display crosshair while in menus and automap
- r_fog.c: do not access lump array with -1 index