### PR TITLE
fix performance regression with PNG textures with alpha=255

### DIFF
--- a/src/engine/gl_texture.c
+++ b/src/engine/gl_texture.c
@@ -249,7 +249,7 @@ static void GL_WorldTexClassify(int texnum)
 			break;
 	}
 	g_tex_is_translucent[texnum] = (unsigned char)hasMid;
-	g_tex_is_masked[texnum] = (unsigned char)(!hasMid && has0);
+	g_tex_is_masked[texnum] = (unsigned char)(!hasMid && (has0 || has255));
 
 	Z_Free(png);
 }


### PR DESCRIPTION
This fixes performance (fps) being tanked by calling repeatedly `I_PNGReadData()` if a texture has all its alpha set to 255.
Best observed on Ethereal start hub map which has plenty of these