### PR TITLE
Change the type for `skyfadeback` to `bool` in "r_sky.h"

### DIFF
--- a/src/engine/r_sky.h
+++ b/src/engine/r_sky.h
@@ -27,7 +27,7 @@ extern int          skybackdropnum;
 extern int          thunderCounter;
 extern int          lightningCounter;
 extern int          thundertic;
-extern boolean			skyfadeback;
+extern bool         skyfadeback;
 
 // Needed to store the number of the dummy sky flat.
 // Used for rendering, as well as tracking projectiles etc.


### PR DESCRIPTION
Fixes the game not compiling with GCC