### PR TITLE
Fix the `gamepad64` redeclaration compiler error

### DIFF
--- a/src/engine/i_sdlinput.c
+++ b/src/engine/i_sdlinput.c
@@ -1,4 +1,4 @@
-﻿// Emacs style mode select   -*- C -*-
+// Emacs style mode select   -*- C -*-
 //-----------------------------------------------------------------------------
 //
 // Copyright(C) 1993-1997 Id Software, Inc.
@@ -47,6 +47,8 @@ int	DualMouse;
 boolean	DigiJoy;
 boolean	MouseMode;
 boolean	window_mouse;
+
+gamepad64_t gamepad64;
 
 //
 // SDL3 Gamepad

--- a/src/engine/i_sdlinput.h
+++ b/src/engine/i_sdlinput.h
@@ -20,6 +20,9 @@
 //
 //-----------------------------------------------------------------------------
 
+#ifndef __I_SDLINPUT__
+#define __I_SDLINPUT__
+
 #include <SDL3/SDL.h>
 
 #include "doomtype.h"
@@ -49,7 +52,7 @@ const char* I_KeycodeToName_All(int keycode);
 int I_NameToKeycode_All(const char* name);
 void I_RegisterGamepadKeyNames(void);
 
-struct {
+typedef struct {
 	SDL_Gamepad* gamepad;
 	SDL_Joystick* joy;
 	SDL_JoystickID active_id;
@@ -63,4 +66,6 @@ struct {
 	float gamepad_look_fx, gamepad_look_fy, gamepad_look_dx, gamepad_look_dy;
 
 	bool init;
-} gamepad64;
+} gamepad64_t;
+
+#endif

--- a/src/engine/wi_stuff.c
+++ b/src/engine/wi_stuff.c
@@ -37,6 +37,8 @@
 
 #define WIALPHARED      D_RGBA(0xC0, 0, 0, 0xFF)
 
+extern gamepad64_t gamepad64;
+
 static int itempercent[MAXPLAYERS];
 static int itemvalue[MAXPLAYERS];
 


### PR DESCRIPTION
Fixes these errors:
```
[  1%] Linking C executable DOOM64EX-Plus
/usr/bin/ld: CMakeFiles/DOOM64EX-Plus.dir/src/engine/am_map.c.o:(.bss+0x20): multiple definition of `gamepad64'; CMakeFiles/DOOM64EX-Plus.dir/src/engine/i_system.c.o:(.bss+0x40): first defined here
/usr/bin/ld: CMakeFiles/DOOM64EX-Plus.dir/src/engine/con_cvar.c.o:(.bss+0x20): multiple definition of `gamepad64'; CMakeFiles/DOOM64EX-Plus.dir/src/engine/i_system.c.o:(.bss+0x40): first defined here
/usr/bin/ld: CMakeFiles/DOOM64EX-Plus.dir/src/engine/d_devstat.c.o:(.bss+0x0): multiple definition of `gamepad64'; CMakeFiles/DOOM64EX-Plus.dir/src/engine/i_system.c.o:(.bss+0x40): first defined here
/usr/bin/ld: CMakeFiles/DOOM64EX-Plus.dir/src/engine/d_main.c.o:(.bss+0xe00): multiple definition of `gamepad64'; CMakeFiles/DOOM64EX-Plus.dir/src/engine/i_system.c.o:(.bss+0x40): first defined here
/usr/bin/ld: CMakeFiles/DOOM64EX-Plus.dir/src/engine/d_net.c.o:(.bss+0x14e0): multiple definition of `gamepad64'; CMakeFiles/DOOM64EX-Plus.dir/src/engine/i_system.c.o:(.bss+0x40): first defined here
/usr/bin/ld: CMakeFiles/DOOM64EX-Plus.dir/src/engine/g_game.c.o:(.bss+0xaa0): multiple definition of `gamepad64'; CMakeFiles/DOOM64EX-Plus.dir/src/engine/i_system.c.o:(.bss+0x40): first defined here
/usr/bin/ld: CMakeFiles/DOOM64EX-Plus.dir/src/engine/wi_stuff.c.o:(.bss+0x0): multiple definition of `gamepad64'; CMakeFiles/DOOM64EX-Plus.dir/src/engine/i_system.c.o:(.bss+0x40): first defined here
/usr/bin/ld: CMakeFiles/DOOM64EX-Plus.dir/src/engine/m_menu.c.o:(.bss+0x1da0): multiple definition of `gamepad64'; CMakeFiles/DOOM64EX-Plus.dir/src/engine/i_system.c.o:(.bss+0x40): first defined here
/usr/bin/ld: CMakeFiles/DOOM64EX-Plus.dir/src/engine/gl_main.c.o:(.bss+0x180): multiple definition of `gamepad64'; CMakeFiles/DOOM64EX-Plus.dir/src/engine/i_system.c.o:(.bss+0x40): first defined here
/usr/bin/ld: CMakeFiles/DOOM64EX-Plus.dir/src/engine/i_video.c.o:(.bss+0x40): multiple definition of `gamepad64'; CMakeFiles/DOOM64EX-Plus.dir/src/engine/i_system.c.o:(.bss+0x40): first defined here
/usr/bin/ld: CMakeFiles/DOOM64EX-Plus.dir/src/engine/i_sdlinput.c.o:(.bss+0x20): multiple definition of `gamepad64'; CMakeFiles/DOOM64EX-Plus.dir/src/engine/i_system.c.o:(.bss+0x40): first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/DOOM64EX-Plus.dir/build.make:1449: DOOM64EX-Plus] Error 1
make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/DOOM64EX-Plus.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```