### PR TITLE
Disable mouse look and invert in menu

### DIFF
--- a/src/engine/d_devstat.c
+++ b/src/engine/d_devstat.c
@@ -36,6 +36,8 @@ static boolean showstats = true;
 
 extern word statindice;
 
+CVAR_EXTERNAL(v_mlook);
+CVAR_EXTERNAL(v_mlookinvert);
 CVAR_EXTERNAL(sv_lockmonsters);
 
 //
@@ -227,6 +229,31 @@ boolean D_DevKeyResponder(event_t* ev) {
 				players[consoleplayer].message = "Demo Mode On";
 				players[consoleplayer].health = 100;
 				players[consoleplayer].mo->health = 100;
+				return true;
+
+			case KEY_F2:    // toggle spectator mode
+				if (!(players[consoleplayer].cheats & CF_SPECTATOR)) {
+					players[consoleplayer].cheats |= CF_SPECTATOR;
+					players[consoleplayer].message = "Spectator Mode On";
+
+					freelook = (int)v_mlook.value;
+					CON_CvarSetValue(v_mlook.name, 1);
+
+					players[consoleplayer].mo->flags |= MF_FLOAT;
+					players[consoleplayer].mo->flags |= MF_NOCLIP;
+					players[consoleplayer].mo->flags &= ~MF_GRAVITY;
+				}
+				else {
+					players[consoleplayer].cheats &= ~CF_SPECTATOR;
+					players[consoleplayer].message = "Spectator Mode Off";
+
+					CON_CvarSetValue(v_mlook.name, (float)freelook);
+					freelook = false;
+
+					players[consoleplayer].mo->flags &= ~MF_FLOAT;
+					players[consoleplayer].mo->flags &= ~MF_NOCLIP;
+					players[consoleplayer].mo->flags |= MF_GRAVITY;
+				}
 				return true;
 
 			case KEY_F3:    // freeze all mobj thinkers

--- a/src/engine/g_game.c
+++ b/src/engine/g_game.c
@@ -152,6 +152,8 @@ NETCVAR_PARAM(sv_keepitems, 0, gameflags, GF_KEEPITEMS)
 NETCVAR_PARAM(p_autoaim, 1, gameflags, GF_ALLOWAUTOAIM)
 NETCVAR_PARAM(compat_mobjpass, 0, compatflags, COMPATF_MOBJPASS)
 
+CVAR_EXTERNAL(v_mlook);
+CVAR_EXTERNAL(v_mlookinvert);
 CVAR_EXTERNAL(v_yaxismove);
 CVAR_EXTERNAL(v_xaxismove);
 CVAR_EXTERNAL(p_fdoubleclick);
@@ -742,6 +744,13 @@ void G_BuildTiccmd(ticcmd_t* cmd) {
 		}
 
 		cmd->angleturn -= pc->mousex * 0x4;
+
+		
+		if (forcefreelook != 2 && ((int)v_mlook.value || forcefreelook)) {
+			cmd->pitch -= (int)v_mlookinvert.value ? pc->mousey * 0x4 : -(pc->mousey * 0x4);
+		}
+		
+		
 	}
 
 	if ((int)v_yaxismove.value) {
@@ -959,7 +968,7 @@ static void G_SetGameFlags(void) {
 	if (sv_allowcheats.value > 0)   gameflags |= GF_ALLOWCHEATS;
 	if (sv_friendlyfire.value > 0)  gameflags |= GF_FRIENDLYFIRE;
 	if (sv_keepitems.value > 0)     gameflags |= GF_KEEPITEMS;
-	if (p_autoaim.value > 0)		gameflags |= GF_ALLOWAUTOAIM;
+	if (p_autoaim.value > 0 || v_mlook.value <= 0)  gameflags |= GF_ALLOWAUTOAIM; // force autoaim if mlook is disabled
 
 	if (compat_mobjpass.value > 0)  compatflags |= COMPATF_MOBJPASS;
 }

--- a/src/engine/i_png.c
+++ b/src/engine/i_png.c
@@ -30,7 +30,6 @@
 #include "doomtype.h"
 #include "i_system.h"
 #include "i_swap.h"
-#include "m_misc.h"
 #include "z_zone.h"
 #include "w_wad.h"
 #include "gl_texture.h"
@@ -405,7 +404,7 @@ byte* I_PNGReadData(int lump, bool palette, bool nopack, bool alpha,
 
             boolean alpha_handled = false;
 
-            if (usingGL) {
+            if (usingGL) { // !alpha is true
                 int num_trans = 0;
                 png_get_tRNS(png_ptr, info_ptr, NULL, &num_trans, NULL);
                 if (num_trans || (color_type & PNG_COLOR_MASK_ALPHA)) {

--- a/src/engine/i_png.c
+++ b/src/engine/i_png.c
@@ -405,7 +405,7 @@ byte* I_PNGReadData(int lump, bool palette, bool nopack, bool alpha,
 
             boolean alpha_handled = false;
 
-            if (usingGL && !alpha) {
+            if (usingGL) {
                 int num_trans = 0;
                 png_get_tRNS(png_ptr, info_ptr, NULL, &num_trans, NULL);
                 if (num_trans || (color_type & PNG_COLOR_MASK_ALPHA)) {

--- a/src/engine/i_sdlinput.c
+++ b/src/engine/i_sdlinput.c
@@ -34,10 +34,25 @@
 CVAR(v_msensitivityx, 5);
 CVAR(v_msensitivityy, 5);
 CVAR(v_macceleration, 0);
+CVAR(v_mlookinvert, 0);
 CVAR(v_yaxismove, 0);
 CVAR(v_xaxismove, 0);
 CVAR_EXTERNAL(m_menumouse);
 CVAR_EXTERNAL(p_autoaim);
+
+CVAR_CMD(v_mlook, 0) {
+	if (cvar->value > 0) return;
+	// mlook is disabled
+
+	// center player view, resetting pitch
+	if (gamestate == GS_LEVEL) {
+		players[0].mo->pitch = 0;
+	}
+
+	// force autoaim
+	gameflags |= GF_ALLOWAUTOAIM;
+};
+
 
 float mouse_accelfactor;
 
@@ -344,6 +359,7 @@ static void I_GamepadUpdate(void) {
 	}
 	const float sensx = v_msensitivityx.value > 0 ? v_msensitivityx.value : 1.f;
 	const float sensy = v_msensitivityy.value > 0 ? v_msensitivityy.value : 1.f;
+	const float inv = (v_mlookinvert.value ? -1.f : 1.f);
 
 	static float s_look_fx = 0.f, s_look_fy = 0.f;
 	const float dt = (1.0f / 35.0f);
@@ -351,7 +367,7 @@ static void I_GamepadUpdate(void) {
 	s_look_fy = I_GamepadLookSmoothing(s_look_fy, ry, dt, GAMEPAD_LOOK_SMOOTH_TC);
 
 	const float dx = s_look_fx * GAMEPAD_LOOK_BASE_SPEED * sensx * ads_scale;
-	const float dy = s_look_fy * GAMEPAD_LOOK_BASE_SPEED * sensy * ads_scale;
+	const float dy = s_look_fy * GAMEPAD_LOOK_BASE_SPEED * sensy * ads_scale * inv;
 
 	gamepad64.gamepad_look_dx += dx; gamepad64.gamepad_look_dy += dy;
 	const int sdx = (int)gamepad64.gamepad_look_dx;
@@ -723,6 +739,8 @@ void ISDL_RegisterKeyCvars(void) {
 	CON_CvarRegister(&v_msensitivityx);
 	CON_CvarRegister(&v_msensitivityy);
 	CON_CvarRegister(&v_macceleration);
+	CON_CvarRegister(&v_mlook);
+	CON_CvarRegister(&v_mlookinvert);
 	CON_CvarRegister(&v_yaxismove);
 	CON_CvarRegister(&v_xaxismove);
 }

--- a/src/engine/i_sdlinput.c
+++ b/src/engine/i_sdlinput.c
@@ -41,7 +41,11 @@ CVAR_EXTERNAL(m_menumouse);
 CVAR_EXTERNAL(p_autoaim);
 
 CVAR_CMD(v_mlook, 0) {
-	if (cvar->value > 0) return;
+	if (cvar->value > 0) {
+		I_Printf("WARNING: mouse look: skies will not render properly with high pitch. Do not report.\n");
+		return;
+	}
+
 	// mlook is disabled
 
 	// center player view, resetting pitch

--- a/src/engine/i_sdlinput.h
+++ b/src/engine/i_sdlinput.h
@@ -26,7 +26,6 @@
 #include <SDL3/SDL.h>
 
 #include "doomtype.h"
-////////////Input//////////////
 
 extern int UseMouse[2];
 extern int UseJoystick;

--- a/src/engine/m_menu.c
+++ b/src/engine/m_menu.c
@@ -59,6 +59,8 @@
 // definitions
 //
 
+//#define HAS_MENU_MOUSE_LOOK
+
 #define MENUSTRINGSIZE      32
 #define SKULLXOFF           -40    //villsa: changed from -32 to -40
 #define SKULLXTEXTOFF       -24
@@ -774,7 +776,6 @@ void M_PlayerSetName(int choice);
 void M_DrawNetwork(void);
 
 CVAR_EXTERNAL(m_playername);
-//Andr�: remove autoaim and use the normal aim instead.  CVAR_EXTERNAL(p_autoaim);
 CVAR_EXTERNAL(sv_nomonsters);
 CVAR_EXTERNAL(sv_fastmonsters);
 CVAR_EXTERNAL(sv_respawnitems);
@@ -1274,16 +1275,20 @@ void M_DrawMisc(void) {
 
 void M_ChangeSensitivity(int choice);
 void M_ChangeMouseAccel(int choice);
+#ifdef HAS_MENU_MOUSE_LOOK
 void M_ChangeMouseLook(int choice);
 void M_ChangeMouseInvert(int choice);
+#endif
 void M_ChangeYAxisMove(int choice);
 void M_ChangeXAxisMove(int choice);
 void M_DrawMouse(void);
 
 CVAR_EXTERNAL(v_msensitivityx);
 CVAR_EXTERNAL(v_msensitivityy);
+#ifdef HAS_MENU_MOUSE_LOOK
 CVAR_EXTERNAL(v_mlook);
 CVAR_EXTERNAL(v_mlookinvert);
+#endif
 CVAR_EXTERNAL(v_yaxismove);
 CVAR_EXTERNAL(v_xaxismove);
 CVAR_EXTERNAL(v_macceleration);
@@ -1295,8 +1300,10 @@ enum {
 	mouse_empty2,
 	mouse_accel,
 	mouse_empty3,
+#ifdef HAS_MENU_MOUSE_LOOK
 	mouse_look,
 	mouse_invert,
+#endif
 	mouse_yaxismove,
 	mouse_xaxismove,
 	mouse_default,
@@ -1311,8 +1318,10 @@ menuitem_t MouseMenu[] = {
 	{-1,"",0},
 	{3, "Mouse Acceleration",M_ChangeMouseAccel, 'a'},
 	{-1, "",0},
+#ifdef HAS_MENU_MOUSE_LOOK
 	{2,"Mouse Look:",M_ChangeMouseLook,'l'},
 	{2,"Invert Look:",M_ChangeMouseInvert, 'i'},
+#endif
 	{2,"Y-Axis Move:",M_ChangeYAxisMove, 'y'},
         {2, "X-Axis Move:", M_ChangeXAxisMove, 'x'},
 	{-2,"Default",M_DoDefaults,'d'},
@@ -1323,8 +1332,10 @@ menudefault_t MouseDefault[] = {
 	{ &v_msensitivityx, 5 },
 	{ &v_msensitivityy, 5 },
 	{ &v_macceleration, 0 },
+#ifdef HAS_MENU_MOUSE_LOOK
 	{ &v_mlook, 0 },
 	{ &v_mlookinvert, 0 },
+#endif
 	{ &v_yaxismove, 0 },
 	{ &v_xaxismove },
 	{ NULL, -1 }
@@ -1360,11 +1371,12 @@ void M_DrawMouse(void) {
 	M_DrawThermo(MouseDef.x, MouseDef.y + LINEHEIGHT * (mouse_sensy + 1), MAXSENSITIVITY, v_msensitivityy.value);
 
 	M_DrawThermo(MouseDef.x, MouseDef.y + LINEHEIGHT * (mouse_accel + 1), 20, v_macceleration.value);
-
+#ifdef HAS_MENU_MOUSE_LOOK
 	Draw_BigText(MouseDef.x + 144, MouseDef.y + LINEHEIGHT * mouse_look, MENUCOLORRED,
 		msgNames[(int)v_mlook.value]);
 	Draw_BigText(MouseDef.x + 144, MouseDef.y + LINEHEIGHT * mouse_invert, MENUCOLORRED,
 		msgNames[(int)v_mlookinvert.value]);
+#endif
 	Draw_BigText(MouseDef.x + 144, MouseDef.y + LINEHEIGHT * mouse_yaxismove, MENUCOLORRED,
 		msgNames[(int)v_yaxismove.value]);
 	Draw_BigText(MouseDef.x + 144, MouseDef.y + LINEHEIGHT * mouse_xaxismove, MENUCOLORRED,
@@ -1441,6 +1453,7 @@ void M_ChangeMouseAccel(int choice)
 	I_MouseAccelChange();
 }
 
+#ifdef HAS_MENU_MOUSE_LOOK
 void M_ChangeMouseLook(int choice) {
 	M_SetOptionValue(choice, 0, 1, 1, &v_mlook);
 }
@@ -1448,6 +1461,7 @@ void M_ChangeMouseLook(int choice) {
 void M_ChangeMouseInvert(int choice) {
 	M_SetOptionValue(choice, 0, 1, 1, &v_mlookinvert);
 }
+#endif
 
 void M_ChangeYAxisMove(int choice) {
 	M_SetOptionValue(choice, 0, 1, 1, &v_yaxismove);

--- a/src/engine/m_menu.c
+++ b/src/engine/m_menu.c
@@ -774,7 +774,7 @@ void M_PlayerSetName(int choice);
 void M_DrawNetwork(void);
 
 CVAR_EXTERNAL(m_playername);
-CVAR_EXTERNAL(p_autoaim);
+//Andr�: remove autoaim and use the normal aim instead.  CVAR_EXTERNAL(p_autoaim);
 CVAR_EXTERNAL(sv_nomonsters);
 CVAR_EXTERNAL(sv_fastmonsters);
 CVAR_EXTERNAL(sv_respawnitems);
@@ -1067,7 +1067,6 @@ menudefault_t MiscDefault[] = {
 	{ &m_menumouse, 1 },
 	{ &m_cursorscale, 8 },
 	{ &p_autorun, 1 },
-	{ &p_autoaim, 1 },
 	{ &p_usecontext, 0 },
 	{ &r_wipe, 1 },
 	{ &r_weaponswitch, 1 },
@@ -1275,12 +1274,16 @@ void M_DrawMisc(void) {
 
 void M_ChangeSensitivity(int choice);
 void M_ChangeMouseAccel(int choice);
+void M_ChangeMouseLook(int choice);
+void M_ChangeMouseInvert(int choice);
 void M_ChangeYAxisMove(int choice);
 void M_ChangeXAxisMove(int choice);
 void M_DrawMouse(void);
 
 CVAR_EXTERNAL(v_msensitivityx);
 CVAR_EXTERNAL(v_msensitivityy);
+CVAR_EXTERNAL(v_mlook);
+CVAR_EXTERNAL(v_mlookinvert);
 CVAR_EXTERNAL(v_yaxismove);
 CVAR_EXTERNAL(v_xaxismove);
 CVAR_EXTERNAL(v_macceleration);
@@ -1292,6 +1295,8 @@ enum {
 	mouse_empty2,
 	mouse_accel,
 	mouse_empty3,
+	mouse_look,
+	mouse_invert,
 	mouse_yaxismove,
 	mouse_xaxismove,
 	mouse_default,
@@ -1306,6 +1311,8 @@ menuitem_t MouseMenu[] = {
 	{-1,"",0},
 	{3, "Mouse Acceleration",M_ChangeMouseAccel, 'a'},
 	{-1, "",0},
+	{2,"Mouse Look:",M_ChangeMouseLook,'l'},
+	{2,"Invert Look:",M_ChangeMouseInvert, 'i'},
 	{2,"Y-Axis Move:",M_ChangeYAxisMove, 'y'},
         {2, "X-Axis Move:", M_ChangeXAxisMove, 'x'},
 	{-2,"Default",M_DoDefaults,'d'},
@@ -1316,6 +1323,8 @@ menudefault_t MouseDefault[] = {
 	{ &v_msensitivityx, 5 },
 	{ &v_msensitivityy, 5 },
 	{ &v_macceleration, 0 },
+	{ &v_mlook, 0 },
+	{ &v_mlookinvert, 0 },
 	{ &v_yaxismove, 0 },
 	{ &v_xaxismove },
 	{ NULL, -1 }
@@ -1352,6 +1361,10 @@ void M_DrawMouse(void) {
 
 	M_DrawThermo(MouseDef.x, MouseDef.y + LINEHEIGHT * (mouse_accel + 1), 20, v_macceleration.value);
 
+	Draw_BigText(MouseDef.x + 144, MouseDef.y + LINEHEIGHT * mouse_look, MENUCOLORRED,
+		msgNames[(int)v_mlook.value]);
+	Draw_BigText(MouseDef.x + 144, MouseDef.y + LINEHEIGHT * mouse_invert, MENUCOLORRED,
+		msgNames[(int)v_mlookinvert.value]);
 	Draw_BigText(MouseDef.x + 144, MouseDef.y + LINEHEIGHT * mouse_yaxismove, MENUCOLORRED,
 		msgNames[(int)v_yaxismove.value]);
 	Draw_BigText(MouseDef.x + 144, MouseDef.y + LINEHEIGHT * mouse_xaxismove, MENUCOLORRED,
@@ -1426,6 +1439,14 @@ void M_ChangeMouseAccel(int choice)
 		break;
 	}
 	I_MouseAccelChange();
+}
+
+void M_ChangeMouseLook(int choice) {
+	M_SetOptionValue(choice, 0, 1, 1, &v_mlook);
+}
+
+void M_ChangeMouseInvert(int choice) {
+	M_SetOptionValue(choice, 0, 1, 1, &v_mlookinvert);
 }
 
 void M_ChangeYAxisMove(int choice) {


### PR DESCRIPTION
- can be enabled at compile time defining HAS_MENU_MOUSE_LOOK macro
- when mouse look is enabled, display a warning about skies in the console