### PR TITLE
Fix old saves crashing the game

### DIFF
--- a/src/engine/gl_texture.c
+++ b/src/engine/gl_texture.c
@@ -334,6 +334,11 @@ void GL_BindWorldTexture(int texnum, int* width, int* height) {
         }                                                                         \
     } while (0)
 
+	/* StevenSYS: Fixes old saves crashing the game, however the textures will be incorrect */
+	if (texnum > sizeof(dtexture*) * numtextures) {
+		return;
+	}
+
 	if (textureptr[texnum][palettetranslation[texnum]]) {
 		dglBindTexture(GL_TEXTURE_2D, textureptr[texnum][palettetranslation[texnum]]);
 		I_ShaderSetUseTexture(1);


### PR DESCRIPTION
Fixes saves before 11e2de5bec09bc7f52c164485e886df01c606655 from crashing, however the textures are incorrect

c8dc722eda9d2d0d4b5e80b353466cf4f3900624:
<img width="1920" height="1080" alt="sshot001" src="https://github.com/user-attachments/assets/7b8d7892-8381-4ef5-a7bd-0121bc3f07cd" />

Latest:
<img width="1920" height="1080" alt="sshot000" src="https://github.com/user-attachments/assets/b1ac88cc-cb10-422d-a1c8-173e0eafa5e5" />
