### PR TITLE
Disable borderless on Linux as it does not work

### DIFF
--- a/src/engine/i_sdlinput.c
+++ b/src/engine/i_sdlinput.c
@@ -564,7 +564,7 @@ boolean I_UpdateGrab(void) {
 	/* 
 		Don't grab the keyboard (SDL_SetWindowKeyboardGrab) because:
 			- we don't need it
-			- it mess up Alt-Tab (only works when not grabbed).
+			- it mess up Alt-Tab (only works when not grabbed). And Tab switches the automap modes
 			- on Linux KDE (Plasma) it prevents global shortcuts to work (brightness, sound, ...)
 			- finally, the SDL doc does not recommend it: "Normal games should not use keyboard grab"
 	*/

--- a/src/engine/i_video.c
+++ b/src/engine/i_video.c
@@ -36,15 +36,15 @@
 #include "gl_main.h"
 #include "con_cvar.h"
 
-
-
-
 SDL_Window* window = NULL;
 SDL_GLContext   glContext = NULL;
 
 CVAR(r_trishader, 1);
-CVAR(v_fullscreen, 0);
 CVAR(v_checkratio, 0);
+#ifdef HAS_FULLSCREEN_BORDERLESS
+CVAR(v_fullscreen, 0);
+#endif
+
 
 CVAR_CMD(v_vsync, 1) {
     SDL_GL_SetSwapInterval((int)v_vsync.value);
@@ -217,11 +217,11 @@ void I_InitScreen(void) {
 
     flags |= SDL_WINDOW_OPENGL | SDL_WINDOW_MAXIMIZED | SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_MOUSE_FOCUS | SDL_WINDOW_HIDDEN | SDL_WINDOW_HIGH_PIXEL_DENSITY;
 
-    if ((int)v_fullscreen.value) {
-        flags |= SDL_WINDOW_FULLSCREEN;
-    } else {
-        flags |= SDL_WINDOW_BORDERLESS;
-    }
+#ifdef HAS_FULLSCREEN_BORDERLESS
+    flags |= (int)v_fullscreen.value ? SDL_WINDOW_FULLSCREEN : SDL_WINDOW_BORDERLESS;
+#else
+    flags |= SDL_WINDOW_FULLSCREEN;
+#endif
 
 #ifdef SDL_PLATFORM_WIN32
     /* if the window is borderless, the NVIDIA driver will make it fullscreen after the first SDL_GL_SwapWindow call :
@@ -242,7 +242,7 @@ void I_InitScreen(void) {
         return;
     }
 
-    if ((int)v_fullscreen.value) {
+    if (flags & SDL_WINDOW_FULLSCREEN) {
         SDL_DisplayID displayid = SDL_GetDisplayForWindow(window);
         if (!displayid) displayid = SDL_GetPrimaryDisplay();
 
@@ -369,6 +369,8 @@ void V_RegisterCvars(void) {
     CON_CvarRegister(&r_trishader);
     CON_CvarRegister(&v_checkratio);
     CON_CvarRegister(&v_vsync);
+#ifdef HAS_FULLSCREEN_BORDERLESS
     CON_CvarRegister(&v_fullscreen);
+#endif
 }
 

--- a/src/engine/i_video.h
+++ b/src/engine/i_video.h
@@ -34,4 +34,8 @@ void V_RegisterCvars();
 extern float display_scale;
 extern int win_px_w, win_px_h;
 
+#ifndef SDL_PLATFORM_LINUX
+#define HAS_FULLSCREEN_BORDERLESS
+#endif
+
 #endif

--- a/src/engine/m_menu.c
+++ b/src/engine/m_menu.c
@@ -36,6 +36,7 @@
 #include "m_misc.h"
 #include "i_system.h"
 #include "i_system_io.h"
+#include "i_video.h"
 #include "z_zone.h"
 #include "st_stuff.h"
 #include "g_actions.h"
@@ -1740,7 +1741,9 @@ void M_ChangeHUDColor(int choice) {
 
 void M_ChangeBrightness(int choice);
 void M_ChangeGammaLevel(int choice);
+#ifdef HAS_FULLSCREEN_BORDERLESS
 void M_ChangeFullscreen(int choice);
+#endif
 void M_ChangeFilter(int choice);
 void M_ChangeWeaponFilter(int choice);
 void M_ChangeObjectFilter(int choice);
@@ -1757,7 +1760,9 @@ CVAR_EXTERNAL(v_checkratio);
 CVAR_EXTERNAL(i_brightness);
 CVAR_EXTERNAL(i_gamma);
 CVAR_EXTERNAL(i_brightness);
+#ifdef HAS_FULLSCREEN_BORDERLESS
 CVAR_EXTERNAL(v_fullscreen);
+#endif
 CVAR_EXTERNAL(r_filter);
 CVAR_EXTERNAL(r_weaponFilter);
 CVAR_EXTERNAL(r_hudFilter);
@@ -1795,7 +1800,9 @@ menuitem_t VideoMenu[] = {
 	{-1,"",0},
 	{3,"Gamma Correction",M_ChangeGammaLevel, 'g'},
 	{-1,"",0},
+#ifdef HAS_FULLSCREEN_BORDERLESS
 	{2,"Fullscreen:",M_ChangeFullscreen, 'f'},
+#endif
 	{2,"Filter:",M_ChangeFilter, 'f'},
 	{2,"Weapon Filter:",M_ChangeWeaponFilter, 't'},
 	{2,"Object Filter:",M_ChangeObjectFilter, 't'},
@@ -1815,7 +1822,9 @@ char* VideoHints[video_end] = {
 	NULL,
 	"adjust screen gamma",
 	NULL,
+#ifdef HAS_FULLSCREEN_BORDERLESS
 	"toggle fullscreen mode - requires restart",
+#endif
 	"toggle texture filtering - requires restart",
 	"toggle texture filtering on the weapon",
 	"toggle texture filtering on world objects",
@@ -1831,7 +1840,9 @@ char* VideoHints[video_end] = {
 menudefault_t VideoDefault[] = {
 	{ &i_brightness, 0 },
 	{ &i_gamma, 0 },
+#ifdef HAS_FULLSCREEN_BORDERLESS
 	{ &v_fullscreen, 0 },
+#endif
 	{ &r_filter, 0 },
 	{ &r_weaponFilter, 0 },
 	{ &r_objectFilter, 0 },
@@ -1926,7 +1937,9 @@ void M_DrawVideo(void) {
 
 #define DRAWVIDEOITEM2(a, b, c) DRAWVIDEOITEM(a, c[(int)b])
 
+#ifdef HAS_FULLSCREEN_BORDERLESS
 	DRAWVIDEOITEM2(video_fullscreen, v_fullscreen.value, onofftype);
+#endif
 	DRAWVIDEOITEM2(filter, r_filter.value, filterType1);
 	DRAWVIDEOITEM2(object_filter, r_objectFilter.value, filterType2);
 	DRAWVIDEOITEM2(weapon_filter, r_weaponFilter.value, filterType2);
@@ -2009,9 +2022,11 @@ void M_ChangeGammaLevel(int choice)
 	}
 }
 
+#ifdef HAS_FULLSCREEN_BORDERLESS
 void M_ChangeFullscreen(int choice) {
 	M_SetOptionValue(choice, 0, 1, 1, &v_fullscreen);
 }
+#endif
 
 void M_ChangeFilter(int choice) {
 	M_SetOptionValue(choice, 0, 2, 1, &r_filter);


### PR DESCRIPTION
`SDL_WINDOW_BORDERLESS` does not work as expected on Linux (Xorg and Wayland):
- on GNOME and KDE (Plasma) the top bar and taskbar (respectively) are always drawn on top of the window
- on i3 window manager, the game does not draw over the area for the title bar

On the other side, `SDL_WINDOW_FULLSCREEN` works properly.
On Linux,  the Windows distinction between fullscreen borderless and exclusive fullscreen does not exist.
Always create window as `SDL_WINDOW_FULLSCREEN` on Linux
