### PR TITLE
fix scaling on Wayland

### DIFF
--- a/src/engine/g_settings.c
+++ b/src/engine/g_settings.c
@@ -160,6 +160,10 @@ void G_ExecuteFile(char* name) {
 // G_LoadSettings
 //
 
+boolean g_in_load_settings = false;
+
 void G_LoadSettings(void) {
+	g_in_load_settings = true;
 	G_ExecuteFile(G_GetConfigFileName());
+	g_in_load_settings = false;
 }

--- a/src/engine/g_settings.h
+++ b/src/engine/g_settings.h
@@ -19,8 +19,12 @@
 #ifndef G_SETTINGS_H
 #define G_SETTINGS_H
 
+#include "doomtype.h"
+
 void G_LoadSettings(void);
 void G_ExecuteFile(char* name);
 char* G_GetConfigFileName(void);
+
+extern boolean g_in_load_settings;
 
 #endif

--- a/src/engine/i_sdlinput.c
+++ b/src/engine/i_sdlinput.c
@@ -30,6 +30,7 @@
 #include "d_main.h"
 #include "con_cvar.h"
 #include "dgl.h"
+#include "g_settings.h"
 
 CVAR(v_msensitivityx, 5);
 CVAR(v_msensitivityy, 5);
@@ -42,7 +43,9 @@ CVAR_EXTERNAL(p_autoaim);
 
 CVAR_CMD(v_mlook, 0) {
 	if (cvar->value > 0) {
-		I_Printf("WARNING: mouse look: skies will not render properly with high pitch. Do not report.\n");
+		if(!g_in_load_settings) {
+			I_Printf("WARNING: mouse look: skies will not render properly with high pitch. Do not report.\n");
+		}
 		return;
 	}
 


### PR DESCRIPTION
Wayland:
   - use `SDL_HINT_VIDEO_WAYLAND_SCALE_TO_DISPLAY=1` to fix scaling
   - thus no need to force `x11` video driver anymore
   - don't set the GL version to 3.1 as it does not work with Intel UHD graphics
   
Other:
   - when changing `v_fullscreen`, added console message about restarting the game
   - do not display console messages for some cvars init on game startup (`v_mlook`, `v_fullscreen`)