### PR TITLE
Fix console key not working on all keyboards

### DIFF
--- a/src/engine/con_console.c
+++ b/src/engine/con_console.c
@@ -335,8 +335,7 @@ boolean CON_Responder(event_t* ev) {
 	case CST_LOWER:
 		if (ev->type == ev_keydown) {
 			switch (c) {
-			case '~':
-			case '`':
+			case KEY_CONSOLE:
 				CON_dismiss();
 				break;
 
@@ -436,11 +435,7 @@ boolean CON_Responder(event_t* ev) {
 
 	case CST_UP:
 	case CST_RAISE:
-		// AB (GIB) - Oh Kaiser...  you plumb! :)
-		// Why the hell do this?  It only works on UK/US keyboards
-		// Gibbon fixes it!
-		//if(c == '`') { <-- BOO!
-		if (c == '~' || c == '`') {
+		if (c == KEY_CONSOLE) {
 			if (ev->type == ev_keydown) {
 				console_state = CST_DOWN;
 				console_enabled = true;

--- a/src/engine/doomdef.h
+++ b/src/engine/doomdef.h
@@ -291,7 +291,11 @@ extern boolean windowpause;
 #define KEY_MWHEELUP            (0x80 + 0x6b)
 #define KEY_MWHEELDOWN          (0x80 + 0x6c)
 
+#define KEY_CONSOLE				'`'
+
 //code assumes MOUSE_BUTTONS<10
 #define MOUSE_BUTTONS        9
+
+
 
 #endif          // __DOOMDEF__

--- a/src/engine/i_sdlinput.c
+++ b/src/engine/i_sdlinput.c
@@ -417,9 +417,9 @@ static void I_GamepadUpdate(void) {
 //
 
 // Modernised, it was really needed!
-static int I_TranslateKey(const int key)
+static int I_TranslateKey(SDL_KeyboardEvent *key_event)
 {
-	struct { int sdl; int eng; } map[] = {
+	static struct { int sdl; int eng; } map[] = {
 		{ SDLK_LEFT,        KEY_LEFTARROW },
 		{ SDLK_RIGHT,       KEY_RIGHTARROW },
 		{ SDLK_UP,          KEY_UPARROW },
@@ -473,12 +473,23 @@ static int I_TranslateKey(const int key)
 		{ SDLK_KP_DIVIDE,   KEY_KEYPADDIVIDE },
 		{ SDLK_KP_PERIOD,   KEY_KEYPADPERIOD },
 	};
+
+	const int key = key_event->key;
+		
+	// key reserved for the console, independent of location on keyboard
+	// Located in the top left corner (on both ANSI and ISO keyboards).
+	if(key_event->scancode == SDL_SCANCODE_GRAVE) {
+		return KEY_CONSOLE;
+	}
+	
 	for (size_t i = 0; i < sizeof(map) / sizeof(map[0]); ++i) {
 		if (key == map[i].sdl) return map[i].eng;
 	}
+	
 	if (key >= 32 && key < 127) {
 		return key;
 	}
+	
 	return 0;
 }
 
@@ -602,7 +613,7 @@ void I_GetEvent(SDL_Event* Event) {
 			break;
 		}
 		event.type = ev_keydown;
-		event.data1 = I_TranslateKey(Event->key.key);
+		event.data1 = I_TranslateKey(&Event->key);
 		if(event.data1) {
 			D_PostEvent(&event);
 		}
@@ -610,7 +621,7 @@ void I_GetEvent(SDL_Event* Event) {
 
 	case SDL_EVENT_KEY_UP:
 		event.type = ev_keyup;
-		event.data1 = I_TranslateKey(Event->key.key);
+		event.data1 = I_TranslateKey(&Event->key);
 		if(event.data1) {
 			D_PostEvent(&event);
 		}

--- a/src/engine/m_menu.c
+++ b/src/engine/m_menu.c
@@ -55,7 +55,6 @@
 #include "net_server.h"
 #include "dgl.h"
 
-
 //
 // definitions
 //
@@ -3681,6 +3680,10 @@ boolean M_Responder(event_t* ev) {
 		if (ch == KEY_ESCAPE) {
 			MenuBindActive = false;
 			M_BuildControlMenu();
+		}
+		else if (ch == KEY_CONSOLE) {
+			// cannot bind reserved console key
+			return false;
 		}
 		else if (G_BindActionByEvent(ev, messageBindCommand)) {
 			MenuBindActive = false;


### PR DESCRIPTION
Console key is now keyboard layout independent as we use the key associated to scancode SDL_SCANCODE_GRAVE always at the same location on the keyboard. Also do not allow to bind that key to controls