### PR TITLE
added -mod option

### DIFF
--- a/src/engine/i_system.c
+++ b/src/engine/i_system.c
@@ -250,7 +250,7 @@ static char* FindDataFile(char* file) {
 	long min_size = dstreq(file, IWAD_FILENAME) ? 10*1024*1014 : 0;
 
 	for (int i = 0; i < SDL_arraysize(dirs); i++) {
-		if ((path = M_FileExistsInDirectory(dirs[i], file, true))) {
+		if ((path = M_FileOrDirExistsInDirectory(dirs[i], file, true))) {
 			if (min_size == 0 || M_FileLengthFromPath(path) > min_size)	return path;
 			I_Printf("Discarding not usable IWAD: %s\n", path);
 		}
@@ -262,7 +262,7 @@ static char* FindDataFile(char* file) {
 
 	if (I_GetRegistryString(HKEY_LOCAL_MACHINE,
 		L"SOFTWARE\\Wow6432Node\\GOG.com\\Games\\1456611261", L"path", gog_install_dir, MAX_PATH)) {
-		if ((path = M_FileExistsInDirectory(gog_install_dir, file, true))) return path;
+		if ((path = M_FileOrDirExistsInDirectory(gog_install_dir, file, true))) return path;
 	}
 
 #endif
@@ -276,7 +276,7 @@ static char* FindDataFile(char* file) {
             && Steam_ResolvePath(steam_install_dir, &game);
     }
 
-    if(steam_install_dir_found && (path = M_FileExistsInDirectory(steam_install_dir, file, true))) return path;
+    if(steam_install_dir_found && (path = M_FileOrDirExistsInDirectory(steam_install_dir, file, true))) return path;
     
 #endif
 

--- a/src/engine/m_misc.c
+++ b/src/engine/m_misc.c
@@ -296,10 +296,10 @@ boolean M_DirExists(const char* path)
 	return path && !stat(path, &st) && S_ISDIR(st.st_mode);
 }
 
-// Returns full path to filename if filename exists within dir
+// Returns full path to filename if filename (as a file or dir) exists within dir
 // Returns NULL if dirpath is NULL or empty string
 // Must be freed by caller
-char* M_FileExistsInDirectory(char* dirpath, char* filename, boolean log) {
+char* M_FileOrDirExistsInDirectory(char* dirpath, char* filename, boolean log) {
 
 	filepath_t path;
 
@@ -309,7 +309,7 @@ char* M_FileExistsInDirectory(char* dirpath, char* filename, boolean log) {
 		char* separator = last_char == '/' || last_char == '\\' ? "" : "/";
 
 		SDL_snprintf(path, MAX_PATH, "%s%s%s", dirpath, separator, filename);
-		if (M_FileExists(path)) {
+		if (M_FileExists(path) || M_DirExists(path)) {
 			if (log) {
 				I_Printf("Found %s\n", path);
 			}

--- a/src/engine/m_misc.h
+++ b/src/engine/m_misc.h
@@ -51,7 +51,7 @@ int M_ReadFile(char* filepath, byte** buffer);
 boolean M_RemoveFile(char* filepath);
 boolean M_FileExists(const char* path);
 boolean M_DirExists(const char* path);
-char* M_FileExistsInDirectory(char* dirpath, char* filename, boolean log);
+char* M_FileOrDirExistsInDirectory(char* dirpath, char* filename, boolean log);
 long M_FileLengthFromPath(char* filepath);
 long M_FileLength(FILE* handle);
 boolean M_MoveFile(char* filename, char* src_dirpath, char* dst_dirpath);

--- a/src/engine/w_wad.h
+++ b/src/engine/w_wad.h
@@ -52,7 +52,6 @@ void* W_CacheLumpNum(int lump, int tag);
 void* W_CacheLumpName(const char* name, int tag);
 boolean W_LumpNameEq(lumpinfo_t* lump, const char* name);
 
-void W_KPFInit(void);
 boolean W_KPFLoadInner(const char* inner, unsigned char** data, int* size);
 
 #endif


### PR DESCRIPTION
Conveniently combines `-file` and `-kpf`:

As argument, it takes an absolute or relative path to a folder containing a mod. If relative and not found, the specified mod directory is searched as a subdir of the data directories
- if the mod directory is resolved, the largest WAD file is loaded as if specified to `-file`
- if the `kpf/Doom64` subdirectory exists within the mod directory, it is loaded as if specified to `-kpf`

Examples:

```
DOOM64EX+.exe -mod Ethereal
```

`Ethereal` directory will be searched in the user's data dir, GOG dir, Steam dir, dir from where the exe is started


Specifying an absolute path:

```
DOOM64EX+.exe -mod /full/path/to/Ethereal
```