### PR TITLE
Add support for secondary (photosensitivity) splash screen

### DIFF
--- a/src/engine/w_wad.h
+++ b/src/engine/w_wad.h
@@ -21,6 +21,8 @@
 
 #include "w_file.h"
 
+#define PHOTOSENSWARNING_LUMP "PHSENSW"
+
 //
 // WADFILE I/O related stuff.
 //
@@ -53,5 +55,7 @@ void* W_CacheLumpName(const char* name, int tag);
 boolean W_LumpNameEq(lumpinfo_t* lump, const char* name);
 
 boolean W_KPFLoadInner(const char* inner, unsigned char** data, int* size);
+
+
 
 #endif


### PR DESCRIPTION
Implemented mainly for mods
if a custom kpf is specified, look for `gfx/PhotosensitivityWarning.png` and if present display it after `USLEGAL`

Most mods use the same graphics for `USLEGAL` (`gfx/legals.png`) and  `gfx/PhotosensitivityWarning.png` to display some
credits or story text. If it is the same graphics it will now be displayed twice, thus visible a bit longer.
However, some mods like Ethereal have a different `PhotosensitivityWarning.png` graphic and with this patch you can see both graphics.

I disabled showing the stock `Doom64.kpf` photo sensitivty graphics but we could:

- display it only once, the first time a user starts DOOM64EX+
- display it every time like the Remaster
- never display it like currently

I think displaying it every time might be a bit too much. Once on first run would be great I think but not displaying at all is OK as well. Thoughts ?