### PR TITLE
-file option also searches in data dirs

### DIFF
--- a/src/engine/m_misc.c
+++ b/src/engine/m_misc.c
@@ -74,8 +74,10 @@ int M_CheckParm(const char* check) {
 	return 0;
 }
 
+// NULL-safe
 char* M_StringDuplicate(char* s)
 {
+	if (!s) return NULL;
 #ifdef _MSC_VER
 	return _strdup(s);
 #else


### PR DESCRIPTION
Previously it only accepted an absolute or relative file path to a .wad. Now it accepts a wad filename and will search it in all data dirs (user's data dir, Gog, Steam etc).
If `-mod` is specified, the mod directory will be checked as well

Example:

```
DOOM64EX+ -file jdagenet_anguish.wad -warp 1
```

Single map `jdagenet_anguish.wad` will be found if for example it is in the user's data dir (on Windows: `C:\Users\<username>\AppData\Roaming\doom64ex-plus`)

Also, if any file or directory specified with `-file`, `-kpf` and `-mod` option is not found, the program will exit with a message box about the file/dir that cannot be found