### PR TITLE
align vtx_t, dPalette_t, use dglInterleavedArrays

### DIFF
--- a/src/engine/dgl.c
+++ b/src/engine/dgl.c
@@ -93,9 +93,7 @@ void dglSetVertex(vtx_t* vtx) {
 		return;
 	}
 
-	dglTexCoordPointer(2, GL_FLOAT, sizeof(vtx_t), &vtx->tu);
-	dglVertexPointer(3, GL_FLOAT, sizeof(vtx_t), vtx);
-	dglColorPointer(4, GL_UNSIGNED_BYTE, sizeof(vtx_t), &vtx->r);
+	dglInterleavedArrays(GL_T2F_C4UB_V3F, sizeof(vtx_t), (GLvoid*)vtx);
 
 	dgl_prevptr = vtx;
 }

--- a/src/engine/doomtype.h
+++ b/src/engine/doomtype.h
@@ -34,4 +34,15 @@ typedef unsigned short		word;
 #define BETWEEN(l,u,x) ((l)>(x)?(l):(x)>(u)?(u):(x))
 #endif
 
+// Platform independent aligned attribute
+#if defined(_MSC_VER)
+#define ALIGNED(x) __declspec(align(x))
+#elif defined(__GNUC__) || defined(__clang__)
+#define ALIGNED(x) __attribute__((aligned(x)))
+#else
+#define ALIGNED(x) 
 #endif
+
+
+#endif
+

--- a/src/engine/gl_main.h
+++ b/src/engine/gl_main.h
@@ -22,35 +22,37 @@
 #include "doomtype.h"
 
 typedef GLuint        dtexture;
-typedef GLfloat        rfloat;
-typedef GLuint        rcolor;
-typedef GLuint        rbuffer;
+typedef GLfloat         rfloat;
+typedef GLuint          rcolor;
+typedef GLuint         rbuffer;
 typedef GLhandleARB    rhandle;
 
 extern int gl_max_texture_units;
 extern int gl_max_texture_size;
 extern boolean gl_has_combiner;
 
-typedef struct {
-	rfloat    x;
-	rfloat    y;
-	rfloat    z;
+#define MAXSPRPALSETS       4
+
+#pragma pack(push,1)
+typedef struct ALIGNED(4) {
+union { struct { byte r,g,b,a; }; rcolor rgba; };
+} dPalette_t;
+#pragma pack(pop)
+
+#pragma pack(push,1)
+typedef struct ALIGNED(32) {
 	rfloat    tu;
 	rfloat    tv;
 	byte r;
 	byte g;
 	byte b;
 	byte a;
+	rfloat     x;
+	rfloat     y;
+	rfloat     z;
+	dPalette_t l[2];
 } vtx_t;
-
-#define MAXSPRPALSETS       4
-
-typedef struct {
-	byte r;
-	byte g;
-	byte b;
-	byte a;
-} dPalette_t;
+#pragma pack(pop)
 
 #define GLSTATE_BLEND       0
 #define GLSTATE_CULL        1

--- a/src/engine/t_bsp.h
+++ b/src/engine/t_bsp.h
@@ -56,12 +56,14 @@ typedef struct {
 	fixed_t        z;
 } degenmobj_t;
 
-typedef struct {
+#pragma pack(push, 1)
+typedef struct ALIGNED(16) {
 	fixed_t a;
 	fixed_t b;
 	fixed_t c;
 	fixed_t d;
 } plane_t;
+#pragma pack(pop)
 
 //
 // The SECTORS record, at runtime.


### PR DESCRIPTION
- add `ALIGNED(x)` to be used after `typedef struct`
- `align` and `pad` `vtx_t` to `32` bytes for `optimal` aligned `transfer` size
- `align` `dPalettte_t` to `4` bytes
- `align` `plane_t`
- use `glInterleavedArrays` with `stride` of `sizeof(vtx_t)` for `SetVertex`
